### PR TITLE
MODREQMED-15: Update version of interface "tenant" to 2.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -44,15 +44,21 @@
     },
     {
       "id": "_tenant",
-      "version": "1.2",
+      "version": "2.0",
       "interfaceType": "system",
       "handlers": [
         {
-          "methods": ["POST"],
+          "methods": [
+            "POST"
+          ],
           "pathPattern": "/_/tenant"
-        }, {
-          "methods": ["DELETE"],
-          "pathPattern": "/_/tenant"
+        },
+        {
+          "methods": [
+            "GET",
+            "DELETE"
+          ],
+          "pathPattern": "/_/tenant/{id}"
         }
       ]
     }

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-backend-testing</artifactId>
-      <version>1.5.5-SNAPSHOT</version>
+      <version>1.5.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Purpose
Update version of interface “_tenant” from 1.2 to 2.0 in order to fix module’s deployment in Eureka-enabled environment.
[MODREQMED-15](https://folio-org.atlassian.net/browse/MODREQMED-15)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
