### PR TITLE
MODREQMED-16: Create skeleton for a new endpoint - send item in transit

### DIFF
--- a/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
 import org.folio.mr.domain.dto.MediatedRequest;
 import org.folio.mr.domain.dto.MediatedRequests;
+import org.folio.mr.domain.dto.SendItemInTransitRequest;
 import org.folio.mr.rest.resource.RequestsMediatedApi;
 import org.folio.mr.service.MediatedRequestsService;
 import org.springframework.http.HttpStatus;
@@ -64,6 +65,11 @@ public class MediatedRequestsController implements RequestsMediatedApi {
 
   @Override
   public ResponseEntity<Void> confirmItemArrival(ConfirmItemArrivalRequest request) {
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @Override
+  public ResponseEntity<Void> sendItemInTransit(SendItemInTransitRequest mediatedRequest) {
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
@@ -63,7 +63,7 @@ public class MediatedRequestsController implements RequestsMediatedApi {
   }
 
   @Override
-  public ResponseEntity<Void> confirmItemArrival(String itemBarcode, ConfirmItemArrivalRequest request) {
+  public ResponseEntity<Void> confirmItemArrival(ConfirmItemArrivalRequest request) {
     return ResponseEntity.ok(null);
   }
 }

--- a/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
@@ -64,6 +64,6 @@ public class MediatedRequestsController implements RequestsMediatedApi {
 
   @Override
   public ResponseEntity<Void> confirmItemArrival(ConfirmItemArrivalRequest request) {
-    return ResponseEntity.ok(null);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
@@ -2,6 +2,7 @@ package org.folio.mr.controller;
 
 import java.util.UUID;
 
+import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
 import org.folio.mr.domain.dto.MediatedRequest;
 import org.folio.mr.domain.dto.MediatedRequests;
 import org.folio.mr.rest.resource.RequestsMediatedApi;
@@ -59,5 +60,10 @@ public class MediatedRequestsController implements RequestsMediatedApi {
     return mediatedRequestsService.delete(requestId)
       .map(entity -> ResponseEntity.status(HttpStatus.NO_CONTENT).<Void>build())
       .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  @Override
+  public ResponseEntity<Void> confirmItemArrival(String itemBarcode, ConfirmItemArrivalRequest request) {
+    return ResponseEntity.ok(null);
   }
 }

--- a/src/main/resources/swagger.api/requests-mediated.yaml
+++ b/src/main/resources/swagger.api/requests-mediated.yaml
@@ -131,6 +131,8 @@ paths:
               $ref: '#/components/schemas/confirmItemArrivalRequest'
         required: true
       responses:
+        '200':
+          description: Successful operation, no content returned
         '400':
           $ref: '#/components/responses/badRequestResponse'
         '500':

--- a/src/main/resources/swagger.api/requests-mediated.yaml
+++ b/src/main/resources/swagger.api/requests-mediated.yaml
@@ -118,10 +118,31 @@ paths:
           $ref: '#/components/responses/notFoundResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
+  /requests-mediated/confirm-item-arrival:
+    post:
+      description: Confirm item arrival
+      operationId: confirmItemArrival
+      tags:
+        - mediatedRequest
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/confirmItemArrivalRequest'
+        required: true
+      parameters:
+        - $ref: '#/components/parameters/itemBarcode'
+      responses:
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
 components:
   schemas:
     mediatedRequest:
       $ref: 'schemas/mediatedRequest.yaml#/MediatedRequest'
+    confirmItemArrivalRequest:
+      $ref: 'schemas/confirmItemArrivalRequest.yaml#/ConfirmItemArrivalRequest'
     errorResponse:
       $ref: 'schemas/errors.json'
   parameters:
@@ -132,6 +153,13 @@ components:
       schema:
         type: string
         format: uuid
+    itemBarcode:
+      name: itemBarcode
+      in: query
+      required: true
+      description: The barcode number of the item arrived.
+      schema:
+        type: string
     trait_queryable_query:
       name: query
       in: query

--- a/src/main/resources/swagger.api/requests-mediated.yaml
+++ b/src/main/resources/swagger.api/requests-mediated.yaml
@@ -131,7 +131,7 @@ paths:
               $ref: '#/components/schemas/confirmItemArrivalRequest'
         required: true
       responses:
-        '200':
+        '204':
           description: Successful operation, no content returned
         '400':
           $ref: '#/components/responses/badRequestResponse'

--- a/src/main/resources/swagger.api/requests-mediated.yaml
+++ b/src/main/resources/swagger.api/requests-mediated.yaml
@@ -130,8 +130,6 @@ paths:
             schema:
               $ref: '#/components/schemas/confirmItemArrivalRequest'
         required: true
-      parameters:
-        - $ref: '#/components/parameters/itemBarcode'
       responses:
         '400':
           $ref: '#/components/responses/badRequestResponse'
@@ -153,13 +151,6 @@ components:
       schema:
         type: string
         format: uuid
-    itemBarcode:
-      name: itemBarcode
-      in: query
-      required: true
-      description: The barcode number of the item arrived.
-      schema:
-        type: string
     trait_queryable_query:
       name: query
       in: query

--- a/src/main/resources/swagger.api/requests-mediated.yaml
+++ b/src/main/resources/swagger.api/requests-mediated.yaml
@@ -118,6 +118,25 @@ paths:
           $ref: '#/components/responses/notFoundResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
+  /requests-mediated/send-item-in-transit:
+    post:
+      description: Send item in transit
+      operationId: sendItemInTransit
+      tags:
+        - mediatedRequest
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sendItemInTransitRequest'
+        required: true
+      responses:
+        '204':
+          description: Successful operation, no content returned
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
   /requests-mediated/confirm-item-arrival:
     post:
       description: Confirm item arrival
@@ -141,6 +160,8 @@ components:
   schemas:
     mediatedRequest:
       $ref: 'schemas/mediatedRequest.yaml#/MediatedRequest'
+    sendItemInTransitRequest:
+      $ref: 'schemas/sendItemInTransitRequest.yaml#/SendItemInTransitRequest'
     confirmItemArrivalRequest:
       $ref: 'schemas/confirmItemArrivalRequest.yaml#/ConfirmItemArrivalRequest'
     errorResponse:

--- a/src/main/resources/swagger.api/schemas/confirmItemArrivalRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/confirmItemArrivalRequest.yaml
@@ -3,7 +3,7 @@ ConfirmItemArrivalRequest:
   type: object
   properties:
     itemBarcode:
-      description: Barcode number of the item
+      description: Barcode of the confirmed item
       type: string
   required:
     - itemBarcode

--- a/src/main/resources/swagger.api/schemas/confirmItemArrivalRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/confirmItemArrivalRequest.yaml
@@ -1,0 +1,9 @@
+ConfirmItemArrivalRequest:
+  description: Confirm item arrival request
+  type: object
+  properties:
+    itemBarcode:
+      description: Barcode number of the item
+      type: string
+  required:
+    - itemBarcode

--- a/src/main/resources/swagger.api/schemas/sendItemInTransitRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/sendItemInTransitRequest.yaml
@@ -1,0 +1,9 @@
+SendItemInTransitRequest:
+  description: Send item in transit request
+  type: object
+  properties:
+    itemBarcode:
+      description: Barcode of the sent item in transit
+      type: string
+  required:
+    - itemBarcode

--- a/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
+++ b/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatusCode;
+import org.springframework.http.HttpStatus;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -30,19 +30,19 @@ class MediatedRequestsControllerTest {
     when(requestsService.get(any())).thenReturn(Optional.empty());
     var response = requestsController.getMediatedRequestById(any());
     verify(requestsService).get(any());
-    Assertions.assertEquals(HttpStatusCode.valueOf(404), response.getStatusCode());
+    Assertions.assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
   }
 
   @Test
   void getById() {
     when(requestsService.get(any())).thenReturn(Optional.of(new MediatedRequest()));
     var response = requestsController.getMediatedRequestById(any());
-    Assertions.assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+    Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
   }
 
   @Test
   void confirmItemArrival() {
     var response = requestsController.confirmItemArrival(mock(ConfirmItemArrivalRequest.class));
-    Assertions.assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+    Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
   }
 }

--- a/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
+++ b/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
@@ -1,5 +1,6 @@
 package org.folio.mr.controller;
 
+import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
 import org.folio.mr.domain.dto.MediatedRequest;
 import org.folio.mr.service.MediatedRequestsService;
 import org.junit.jupiter.api.Assertions;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatusCode;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,13 +30,19 @@ class MediatedRequestsControllerTest {
     when(requestsService.get(any())).thenReturn(Optional.empty());
     var response = requestsController.getMediatedRequestById(any());
     verify(requestsService).get(any());
-    Assertions.assertEquals(response.getStatusCode(), HttpStatusCode.valueOf(404));
+    Assertions.assertEquals(HttpStatusCode.valueOf(404), response.getStatusCode());
   }
 
   @Test
   void getById() {
     when(requestsService.get(any())).thenReturn(Optional.of(new MediatedRequest()));
     var response = requestsController.getMediatedRequestById(any());
-    Assertions.assertEquals(response.getStatusCode(), HttpStatusCode.valueOf(200));
+    Assertions.assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+  }
+
+  @Test
+  void confirmItemArrival() {
+    var response = requestsController.confirmItemArrival("", mock(ConfirmItemArrivalRequest.class));
+    Assertions.assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
   }
 }

--- a/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
+++ b/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
@@ -43,6 +43,6 @@ class MediatedRequestsControllerTest {
   @Test
   void confirmItemArrival() {
     var response = requestsController.confirmItemArrival(mock(ConfirmItemArrivalRequest.class));
-    Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
+    Assertions.assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
   }
 }

--- a/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
+++ b/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
@@ -42,7 +42,7 @@ class MediatedRequestsControllerTest {
 
   @Test
   void confirmItemArrival() {
-    var response = requestsController.confirmItemArrival("", mock(ConfirmItemArrivalRequest.class));
+    var response = requestsController.confirmItemArrival(mock(ConfirmItemArrivalRequest.class));
     Assertions.assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
   }
 }

--- a/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
+++ b/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
@@ -2,6 +2,7 @@ package org.folio.mr.controller;
 
 import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
 import org.folio.mr.domain.dto.MediatedRequest;
+import org.folio.mr.domain.dto.SendItemInTransitRequest;
 import org.folio.mr.service.MediatedRequestsService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,12 @@ class MediatedRequestsControllerTest {
   @Test
   void confirmItemArrival() {
     var response = requestsController.confirmItemArrival(mock(ConfirmItemArrivalRequest.class));
+    Assertions.assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+  }
+
+  @Test
+  void sendItemInTransit() {
+    var response = requestsController.sendItemInTransit(mock(SendItemInTransitRequest.class));
     Assertions.assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
   }
 }


### PR DESCRIPTION
## Purpose
Create skeleton for a new endpoint - send item in transit
[MODREQMED-16](https://folio-org.atlassian.net/browse/MODREQMED-16)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
