### PR TITLE
MODREQMED-16: Create skeleton for a new endpoint - send item in transit

### DIFF
--- a/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestsController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
 import org.folio.mr.domain.dto.MediatedRequest;
 import org.folio.mr.domain.dto.MediatedRequests;
+import org.folio.mr.domain.dto.SendItemInTransitRequest;
 import org.folio.mr.rest.resource.RequestsMediatedApi;
 import org.folio.mr.service.MediatedRequestsService;
 import org.springframework.http.HttpStatus;
@@ -64,6 +65,11 @@ public class MediatedRequestsController implements RequestsMediatedApi {
 
   @Override
   public ResponseEntity<Void> confirmItemArrival(ConfirmItemArrivalRequest request) {
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @Override
+  public ResponseEntity<Void> sendItemInTransit(SendItemInTransitRequest mediatedRequest) {
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/resources/swagger.api/requests-mediated.yaml
+++ b/src/main/resources/swagger.api/requests-mediated.yaml
@@ -118,6 +118,25 @@ paths:
           $ref: '#/components/responses/notFoundResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
+  /requests-mediated/send-item-in-transit:
+    post:
+      description: Send item in transit
+      operationId: sendItemInTransit
+      tags:
+        - mediatedRequest
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sendItemInTransitRequest'
+        required: true
+      responses:
+        '204':
+          description: Successful operation, no content returned
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
   /requests-mediated/confirm-item-arrival:
     post:
       description: Confirm item arrival
@@ -141,6 +160,8 @@ components:
   schemas:
     mediatedRequest:
       $ref: 'schemas/mediatedRequest.yaml#/MediatedRequest'
+    sendItemInTransitRequest:
+      $ref: 'schemas/sendItemInTransitRequest.yaml#/SendItemInTransitRequest'
     confirmItemArrivalRequest:
       $ref: 'schemas/confirmItemArrivalRequest.yaml#/ConfirmItemArrivalRequest'
     errorResponse:

--- a/src/main/resources/swagger.api/schemas/sendItemInTransitRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/sendItemInTransitRequest.yaml
@@ -1,0 +1,9 @@
+SendItemInTransitRequest:
+  description: Send item in transit request
+  type: object
+  properties:
+    itemBarcode:
+      description: Barcode of the sent item in transit
+      type: string
+  required:
+    - itemBarcode

--- a/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
+++ b/src/test/java/org/folio/mr/controller/MediatedRequestsControllerTest.java
@@ -2,6 +2,7 @@ package org.folio.mr.controller;
 
 import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
 import org.folio.mr.domain.dto.MediatedRequest;
+import org.folio.mr.domain.dto.SendItemInTransitRequest;
 import org.folio.mr.service.MediatedRequestsService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,12 @@ class MediatedRequestsControllerTest {
   @Test
   void confirmItemArrival() {
     var response = requestsController.confirmItemArrival(mock(ConfirmItemArrivalRequest.class));
+    Assertions.assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+  }
+
+  @Test
+  void sendItemInTransit() {
+    var response = requestsController.sendItemInTransit(mock(SendItemInTransitRequest.class));
     Assertions.assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
   }
 }


### PR DESCRIPTION
## Purpose
Create skeleton for a new endpoint - send item in transit
[MODREQMED-16](https://folio-org.atlassian.net/browse/MODREQMED-16)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._