### PR TITLE
MODREQMED-64: add permissions for mod-settings to system user

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -271,7 +271,9 @@
         "inventory-storage.location-units.libraries.collection.get",
         "mod-settings.entries.item.get",
         "mod-settings.entries.collection.get",
-        "mod-settings.global.read.circulation"
+        "mod-settings.global.read.circulation",
+        "mod-settings.users.read.circulation",
+        "mod-settings.owner.read.circulation"
       ]
     }
   },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -272,8 +272,8 @@
         "mod-settings.entries.item.get",
         "mod-settings.entries.collection.get",
         "mod-settings.global.read.circulation",
-        "mod-settings.users.read.circulation",
-        "mod-settings.owner.read.circulation"
+        "mod-settings.owner.read.circulation",
+        "mod-settings.users.read.circulation"
       ]
     }
   },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -272,8 +272,8 @@
         "mod-settings.entries.item.get",
         "mod-settings.entries.collection.get",
         "mod-settings.global.read.circulation",
-        "mod-settings.owner.read.circulation",
-        "mod-settings.users.read.circulation"
+        "mod-settings.users.read.circulation",
+        "mod-settings.owner.read.circulation"
       ]
     }
   },


### PR DESCRIPTION
## Purpose
Add desired permissions for `GET /settings/entries` to system user.

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
