### PR TITLE
MODREQMED-74: Mediated request workflow - Open - Awaiting pickup status change

### DIFF
--- a/src/main/java/org/folio/mr/service/MediatedRequestActionsService.java
+++ b/src/main/java/org/folio/mr/service/MediatedRequestActionsService.java
@@ -12,6 +12,7 @@ public interface MediatedRequestActionsService {
   void changeStatusToInTransitForApproval(MediatedRequestEntity request);
   MediatedRequest confirmItemArrival(String itemBarcode);
   MediatedRequest sendItemInTransit(String itemBarcode);
+  void changeStatusToAwaitingPickup(MediatedRequestEntity request);
   void decline(UUID mediatedRequestId);
   void cancel(MediatedRequestEntity mediatedRequest, Request confirmedRequest);
   MediatedRequestWorkflowLog saveMediatedRequestWorkflowLog(MediatedRequest request);

--- a/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
+++ b/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.mr.service.impl;
 
 import static java.lang.String.format;
+import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_AWAITING_PICKUP;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_IN_TRANSIT_FOR_APPROVAL;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_IN_TRANSIT_TO_BE_CHECKED_OUT;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_ITEM_ARRIVED;
@@ -176,6 +177,13 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
     log.info("findMediatedRequestForSendingInTransit:: mediated request found: {}", entity::getId);
 
     return entity;
+  }
+
+  @Override
+  public void changeStatusToAwaitingPickup(MediatedRequestEntity request) {
+    log.info("changeStatusToAwaitingPickup:: request id: {}", request.getId());
+    request.setMediatedRequestStatus(MediatedRequestStatus.OPEN);
+    updateMediatedRequestStatus(request, OPEN_AWAITING_PICKUP);
   }
 
   private MediatedRequestEntity updateMediatedRequestStatus(MediatedRequestEntity request,

--- a/src/main/java/org/folio/mr/service/impl/RequestEventHandler.java
+++ b/src/main/java/org/folio/mr/service/impl/RequestEventHandler.java
@@ -2,11 +2,9 @@ package org.folio.mr.service.impl;
 
 import static org.folio.mr.support.KafkaEvent.EventType.UPDATED;
 
-import java.util.EnumSet;
 import java.util.UUID;
 
 import org.folio.mr.domain.dto.Request;
-import org.folio.mr.domain.entity.MediatedRequestEntity;
 import org.folio.mr.repository.MediatedRequestsRepository;
 import org.folio.mr.service.KafkaEventHandler;
 import org.folio.mr.service.MediatedRequestActionsService;
@@ -20,8 +18,6 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class RequestEventHandler implements KafkaEventHandler<Request> {
 
-  protected static final EnumSet<Request.StatusEnum> SUPPORTED_UPDATED_REQUEST_STATUSES =
-    EnumSet.of(Request.StatusEnum.OPEN_IN_TRANSIT, Request.StatusEnum.CLOSED_CANCELLED);
   private final MediatedRequestsRepository mediatedRequestsRepository;
   private final MediatedRequestActionsService actionsService;
 
@@ -44,30 +40,23 @@ public class RequestEventHandler implements KafkaEventHandler<Request> {
       return;
     }
 
+    String requestId = updatedRequest.getId();
     Request.StatusEnum updatedRequestStatus = updatedRequest.getStatus();
-    if (!SUPPORTED_UPDATED_REQUEST_STATUSES.contains(updatedRequest.getStatus())) {
-      log.info("handleRequestUpdateEvent:: updated request status {} is not supported",
-        updatedRequestStatus);
+    log.info("handleRequestUpdateEvent:: handling update event for request {}, status: {}",
+      requestId, updatedRequestStatus);
+
+    var mediatedRequest = mediatedRequestsRepository.findByConfirmedRequestId(
+      UUID.fromString(requestId)).orElse(null);
+    if (mediatedRequest == null) {
+      log.info("handleRequestUpdateEvent:: mediated request not found by confirmed request ID {}",
+        requestId);
       return;
     }
-    log.info("handleRequestUpdateEvent:: updated request status {}", updatedRequestStatus);
-
-    String requestId = updatedRequest.getId();
-    log.info("handleRequestUpdateEvent:: handling update event for request {}", requestId);
-    mediatedRequestsRepository.findByConfirmedRequestId(UUID.fromString(requestId))
-      .ifPresentOrElse(mediatedRequest ->
-          handleRequestUpdateEvent(mediatedRequest, updatedRequest),
-        () -> log.info("handleRequestUpdateEvent:: mediated request not found by confirmed " +
-          "request ID {}", requestId));
-  }
-
-  private void handleRequestUpdateEvent(MediatedRequestEntity mediatedRequest,
-    Request updatedRequest) {
-
-    log.debug("handleRequestUpdateEvent:: mediatedRequest={}", mediatedRequest);
-    Request.StatusEnum updatedRequestStatus = updatedRequest.getStatus();
     if (updatedRequestStatus == Request.StatusEnum.OPEN_IN_TRANSIT) {
       actionsService.changeStatusToInTransitForApproval(mediatedRequest);
+    }
+    if (updatedRequestStatus == Request.StatusEnum.OPEN_AWAITING_PICKUP) {
+      actionsService.changeStatusToAwaitingPickup(mediatedRequest);
     }
     if (updatedRequestStatus == Request.StatusEnum.CLOSED_CANCELLED) {
       actionsService.cancel(mediatedRequest, updatedRequest);


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODREQMED-74

## Approach
Listen to request status change and update corresponding mediated request status

#### TODOS and Open Questions

## Learning
