### PR TITLE
MODREQMED-76: Mediated request workflow - Closed - Filled status change

### DIFF
--- a/src/main/java/org/folio/mr/service/MediatedRequestActionsService.java
+++ b/src/main/java/org/folio/mr/service/MediatedRequestActionsService.java
@@ -14,6 +14,7 @@ public interface MediatedRequestActionsService {
   MediatedRequest sendItemInTransit(String itemBarcode);
   void changeStatusToAwaitingPickup(MediatedRequestEntity request);
   void decline(UUID mediatedRequestId);
-  void cancel(MediatedRequestEntity mediatedRequest, Request confirmedRequest);
+  void changeStatusToClosedFilled(MediatedRequestEntity request);
+  void changeStatusToClosedCanceled(MediatedRequestEntity mediatedRequest, Request confirmedRequest);
   MediatedRequestWorkflowLog saveMediatedRequestWorkflowLog(MediatedRequest request);
 }

--- a/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
+++ b/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
@@ -1,6 +1,9 @@
 package org.folio.mr.service.impl;
 
 import static java.lang.String.format;
+import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.CLOSED_CANCELLED;
+import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.CLOSED_DECLINED;
+import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.CLOSED_FILLED;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_AWAITING_PICKUP;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_IN_TRANSIT_FOR_APPROVAL;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_IN_TRANSIT_TO_BE_CHECKED_OUT;
@@ -202,7 +205,7 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
       .orElseThrow(() -> ExceptionFactory.notFound(format(
         "Mediated request for arrival confirmation of item with barcode '%s' was not found", itemBarcode)));
 
-    log.info("findMediatedRequestForItemArrival:: mediated request found: {}", entity::getId);
+    log.info("findMediatedRequestForItemArrival:: mediated request found: {}", entity.getId());
     return entity;
   }
 
@@ -226,7 +229,7 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
         "Send item in transit: mediated request for item '%s' was not found",
         itemBarcode)));
 
-    log.info("findMediatedRequestForSendingInTransit:: mediated request found: {}", entity::getId);
+    log.info("findMediatedRequestForSendingInTransit:: mediated request found: {}", entity.getId());
 
     return entity;
   }
@@ -236,17 +239,6 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
     log.info("changeStatusToAwaitingPickup:: request id: {}", request.getId());
     request.setMediatedRequestStatus(MediatedRequestStatus.OPEN);
     updateMediatedRequestStatus(request, OPEN_AWAITING_PICKUP);
-  }
-
-  private MediatedRequestEntity updateMediatedRequestStatus(MediatedRequestEntity request,
-    MediatedRequest.StatusEnum newStatus) {
-
-    log.info("updateMediatedRequestStatus:: changing mediated request status from '{}' to '{}'",
-      request.getStatus(), newStatus.getValue());
-    request.setStatus(newStatus.getValue());
-    request.setMediatedRequestStep(MediatedRequestStep.from(newStatus).getValue());
-
-    return mediatedRequestsRepository.save(request);
   }
 
   private void extendMediatedRequest(MediatedRequest request) {
@@ -299,19 +291,7 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
     log.debug("decline:: mediatedRequest: {}", mediatedRequest);
 
     declineRequest(mediatedRequest);
-    mediatedRequestsRepository.save(mediatedRequest);
     log.info("decline:: mediated request {} was successfully declined", id);
-  }
-
-  @Override
-  public void cancel(MediatedRequestEntity mediatedRequest, Request confirmedRequest) {
-    log.info("cancel:: mediatedRequest: {}", mediatedRequest::getId);
-    mediatedRequest.setStatus(MediatedRequest.StatusEnum.CLOSED_CANCELLED.getValue());
-    mediatedRequest.setCancellationReasonId(UUID.fromString(confirmedRequest.getCancellationReasonId()));
-    mediatedRequest.setCancelledDate(confirmedRequest.getCancelledDate());
-    mediatedRequest.setCancelledByUserId(UUID.fromString(confirmedRequest.getCancelledByUserId()));
-    mediatedRequestsRepository.save(mediatedRequest);
-    log.info("cancel:: mediated request {} was successfully cancelled", mediatedRequest::getId);
   }
 
   private void declineRequest(MediatedRequestEntity request) {
@@ -320,10 +300,37 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
     {
       throw ExceptionFactory.validationError("Mediated request status should be 'New - Awaiting conformation'");
     }
-    request.setMediatedRequestStatus(MediatedRequestStatus.CLOSED);
-    request.setStatus(MediatedRequest.StatusEnum.CLOSED_DECLINED.getValue());
-    request.setMediatedRequestStep(MediatedRequestStep.DECLINED.getValue());
     request.setMediatedWorkflow(MediatedRequestWorkflow.PRIVATE_REQUEST.getValue());
+    request.setMediatedRequestStatus(MediatedRequestStatus.CLOSED);
+    updateMediatedRequestStatus(request, CLOSED_DECLINED);
+  }
+
+  @Override
+  public void changeStatusToClosedFilled(MediatedRequestEntity request) {
+    log.info("changeStatusToClosedFilled:: request id: {}", request.getId());
+    request.setMediatedRequestStatus(MediatedRequestStatus.CLOSED);
+    updateMediatedRequestStatus(request, CLOSED_FILLED);
+  }
+
+  @Override
+  public void changeStatusToClosedCanceled(MediatedRequestEntity request, Request confirmedRequest) {
+    log.info("changeStatusToClosedCanceled:: request id: {}", request.getId());
+    request.setCancellationReasonId(UUID.fromString(confirmedRequest.getCancellationReasonId()));
+    request.setCancelledDate(confirmedRequest.getCancelledDate());
+    request.setCancelledByUserId(UUID.fromString(confirmedRequest.getCancelledByUserId()));
+    request.setMediatedRequestStatus(MediatedRequestStatus.CLOSED);
+    updateMediatedRequestStatus(request, CLOSED_CANCELLED);
+  }
+
+  private MediatedRequestEntity updateMediatedRequestStatus(MediatedRequestEntity request,
+                                                            MediatedRequest.StatusEnum newStatus) {
+
+    log.info("updateMediatedRequestStatus:: changing mediated request status from '{}' to '{}'",
+      request.getStatus(), newStatus.getValue());
+    request.setStatus(newStatus.getValue());
+    request.setMediatedRequestStep(MediatedRequestStep.from(newStatus).getValue());
+
+    return mediatedRequestsRepository.save(request);
   }
 
   private MediatedRequestEntity findMediatedRequest(UUID id) {

--- a/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
+++ b/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
@@ -323,7 +323,7 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
   }
 
   private MediatedRequestEntity updateMediatedRequestStatus(MediatedRequestEntity request,
-                                                            MediatedRequest.StatusEnum newStatus) {
+    MediatedRequest.StatusEnum newStatus) {
 
     log.info("updateMediatedRequestStatus:: changing mediated request status from '{}' to '{}'",
       request.getStatus(), newStatus.getValue());

--- a/src/main/java/org/folio/mr/service/impl/RequestEventHandler.java
+++ b/src/main/java/org/folio/mr/service/impl/RequestEventHandler.java
@@ -58,8 +58,11 @@ public class RequestEventHandler implements KafkaEventHandler<Request> {
     if (updatedRequestStatus == Request.StatusEnum.OPEN_AWAITING_PICKUP) {
       actionsService.changeStatusToAwaitingPickup(mediatedRequest);
     }
+    if (updatedRequestStatus == Request.StatusEnum.CLOSED_FILLED) {
+      actionsService.changeStatusToClosedFilled(mediatedRequest);
+    }
     if (updatedRequestStatus == Request.StatusEnum.CLOSED_CANCELLED) {
-      actionsService.cancel(mediatedRequest, updatedRequest);
+      actionsService.changeStatusToClosedCanceled(mediatedRequest, updatedRequest);
     }
   }
 }

--- a/src/test/java/org/folio/mr/controller/KafkaEventListenerTest.java
+++ b/src/test/java/org/folio/mr/controller/KafkaEventListenerTest.java
@@ -3,6 +3,7 @@ package org.folio.mr.controller;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.mr.domain.dto.Request.StatusEnum.CLOSED_CANCELLED;
+import static org.folio.mr.domain.dto.Request.StatusEnum.CLOSED_FILLED;
 import static org.folio.mr.domain.dto.Request.StatusEnum.OPEN_AWAITING_PICKUP;
 import static org.folio.mr.domain.dto.Request.StatusEnum.OPEN_IN_TRANSIT;
 import static org.folio.mr.domain.dto.Request.StatusEnum.OPEN_NOT_YET_FILLED;
@@ -92,6 +93,23 @@ class KafkaEventListenerTest extends BaseIT {
 
     MediatedRequestEntity updatedMediatedRequest = getMediatedRequest(initialMediatedRequest.getId());
     assertEquals(MediatedRequest.StatusEnum.OPEN_AWAITING_PICKUP.getValue(), updatedMediatedRequest.getStatus());
+  }
+
+  @Test
+  void shouldCancelMediatedRequestUponConfirmedRequestFill() {
+    when(tenantConfig.getSecureTenantId()).thenReturn(TENANT_ID_CONSORTIUM);
+    KafkaEvent<Request> event = buildRequestUpdateEvent(OPEN_NOT_YET_FILLED, CLOSED_FILLED);
+    MediatedRequest mediatedRequest =
+      buildMediatedRequest(MediatedRequest.StatusEnum.OPEN_NOT_YET_FILLED);
+    mediatedRequest.setConfirmedRequestId(CONFIRMED_REQUEST_ID.toString());
+    var initialMediatedRequest =
+      createMediatedRequest(mediatedRequestMapper.mapDtoToEntity(mediatedRequest));
+    assertNotNull(initialMediatedRequest.getId());
+
+    publishEventAndWait(TENANT_ID_CONSORTIUM, REQUEST_KAFKA_TOPIC_NAME, event);
+
+    MediatedRequestEntity updatedMediatedRequest = getMediatedRequest(initialMediatedRequest.getId());
+    assertEquals(MediatedRequest.StatusEnum.CLOSED_FILLED.getValue(), updatedMediatedRequest.getStatus());
   }
 
   private static KafkaEvent<Request> buildRequestUpdateEvent(Request.StatusEnum oldStatus,

--- a/src/test/java/org/folio/mr/controller/KafkaEventListenerTest.java
+++ b/src/test/java/org/folio/mr/controller/KafkaEventListenerTest.java
@@ -65,8 +65,7 @@ class KafkaEventListenerTest extends BaseIT {
   void shouldCancelMediatedRequestUponConfirmedRequestCancel() {
     when(tenantConfig.getSecureTenantId()).thenReturn(TENANT_ID_CONSORTIUM);
     KafkaEvent<Request> event = buildRequestUpdateEvent(OPEN_NOT_YET_FILLED, CLOSED_CANCELLED);
-    MediatedRequest mediatedRequest =
-      buildMediatedRequest(MediatedRequest.StatusEnum.OPEN_NOT_YET_FILLED);
+    var mediatedRequest = buildMediatedRequest(MediatedRequest.StatusEnum.OPEN_NOT_YET_FILLED);
     mediatedRequest.setConfirmedRequestId(CONFIRMED_REQUEST_ID.toString());
     var initialMediatedRequest =
       createMediatedRequest(mediatedRequestMapper.mapDtoToEntity(mediatedRequest));
@@ -82,8 +81,7 @@ class KafkaEventListenerTest extends BaseIT {
   void shouldUpdateMediatedRequestStatusOnItemCheckout() {
     when(tenantConfig.getSecureTenantId()).thenReturn(TENANT_ID_CONSORTIUM);
     KafkaEvent<Request> event = buildRequestUpdateEvent(OPEN_IN_TRANSIT, OPEN_AWAITING_PICKUP);
-    MediatedRequest mediatedRequest =
-      buildMediatedRequest(MediatedRequest.StatusEnum.OPEN_IN_TRANSIT_TO_BE_CHECKED_OUT);
+    var mediatedRequest = buildMediatedRequest(MediatedRequest.StatusEnum.OPEN_IN_TRANSIT_TO_BE_CHECKED_OUT);
     mediatedRequest.setConfirmedRequestId(CONFIRMED_REQUEST_ID.toString());
     var initialMediatedRequest =
       createMediatedRequest(mediatedRequestMapper.mapDtoToEntity(mediatedRequest));
@@ -99,8 +97,7 @@ class KafkaEventListenerTest extends BaseIT {
   void shouldCancelMediatedRequestUponConfirmedRequestFill() {
     when(tenantConfig.getSecureTenantId()).thenReturn(TENANT_ID_CONSORTIUM);
     KafkaEvent<Request> event = buildRequestUpdateEvent(OPEN_NOT_YET_FILLED, CLOSED_FILLED);
-    MediatedRequest mediatedRequest =
-      buildMediatedRequest(MediatedRequest.StatusEnum.OPEN_NOT_YET_FILLED);
+    var mediatedRequest = buildMediatedRequest(MediatedRequest.StatusEnum.OPEN_NOT_YET_FILLED);
     mediatedRequest.setConfirmedRequestId(CONFIRMED_REQUEST_ID.toString());
     var initialMediatedRequest =
       createMediatedRequest(mediatedRequestMapper.mapDtoToEntity(mediatedRequest));

--- a/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
+++ b/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
@@ -115,7 +115,6 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void successfulItemArrivalConfirmation() {
-    // given
     UUID mediatedRequestId = UUID.randomUUID();
     MediatedRequestEntity initialRequest = buildMediatedRequestEntity(OPEN_IN_TRANSIT_FOR_APPROVAL)
       .withId(mediatedRequestId);
@@ -133,10 +132,8 @@ class MediatedRequestActionsServiceTest {
     when(circulationRequestService.get(anyString())).thenReturn(new Request());
     when(circulationRequestService.update(any(Request.class))).thenReturn(new Request());
 
-    // when
     MediatedRequest result = mediatedRequestActionsService.confirmItemArrival(itemBarcode);
 
-    // then
     verify(mediatedRequestsRepository).save(any(MediatedRequestEntity.class));
     assertThat(result.getStatus().getValue(), is("Open - Item arrived"));
     assertThat(result.getMediatedRequestStep(), is("Item arrived"));
@@ -159,7 +156,6 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void sendItemInTransitSuccess() {
-    // given
     UUID mediatedRequestId = UUID.randomUUID();
     MediatedRequestEntity initialRequest = buildMediatedRequestEntity(OPEN_ITEM_ARRIVED)
       .withId(mediatedRequestId);
@@ -175,10 +171,8 @@ class MediatedRequestActionsServiceTest {
     when(mediatedRequestMapper.mapEntityToDto(any(MediatedRequestEntity.class)))
       .thenReturn(mappedRequest);
 
-    // when
     MediatedRequest result = mediatedRequestActionsService.sendItemInTransit(itemBarcode);
 
-    // then
     verify(mediatedRequestsRepository).save(any(MediatedRequestEntity.class));
     assertThat(result.getStatus().getValue(), is("Open - In transit to be checked out"));
     assertThat(result.getMediatedRequestStep(), is("In transit to be checked out"));

--- a/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
+++ b/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
@@ -99,16 +99,13 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void changeStatusToInTransitForApprovalSuccess() {
-    // given
     UUID mediatedRequestId = UUID.randomUUID();
     MediatedRequestEntity initialRequest = buildMediatedRequestEntity(OPEN_NOT_YET_FILLED)
       .withId(mediatedRequestId);
     when(mediatedRequestsRepository.save(mediatedRequestEntityCaptor.capture())).thenReturn(null);
 
-    // when
     mediatedRequestActionsService.changeStatusToInTransitForApproval(initialRequest);
 
-    // then
     MediatedRequestEntity updatedRequest = mediatedRequestEntityCaptor.getValue();
     assertNotNull(updatedRequest);
     assertEquals(MediatedRequestStatus.OPEN, updatedRequest.getMediatedRequestStatus());
@@ -127,7 +124,6 @@ class MediatedRequestActionsServiceTest {
     MediatedRequest mappedRequest = buildMediatedRequest(OPEN_ITEM_ARRIVED);
     String itemBarcode = initialRequest.getItemBarcode();
 
-    // when
     when(mediatedRequestsRepository.findRequestForItemArrivalConfirmation(itemBarcode))
       .thenReturn(Optional.of(initialRequest));
     when(mediatedRequestsRepository.save(any(MediatedRequestEntity.class)))
@@ -137,6 +133,7 @@ class MediatedRequestActionsServiceTest {
     when(circulationRequestService.get(anyString())).thenReturn(new Request());
     when(circulationRequestService.update(any(Request.class))).thenReturn(new Request());
 
+    // when
     MediatedRequest result = mediatedRequestActionsService.confirmItemArrival(itemBarcode);
 
     // then
@@ -151,11 +148,9 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void confirmItemArrivalRequestNotFound() {
-    // given
     when(mediatedRequestsRepository.findRequestForItemArrivalConfirmation(any(String.class)))
       .thenReturn(Optional.empty());
 
-    // when-then
     EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
       () -> mediatedRequestActionsService.confirmItemArrival("item-barcode"));
     assertThat(exception.getMessage(),
@@ -191,11 +186,9 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void sendItemInTransitRequestNotFound() {
-    // given
     when(mediatedRequestsRepository.findRequestForSendingInTransit(any(String.class)))
       .thenReturn(Optional.empty());
 
-    // when-then
     EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
       () -> mediatedRequestActionsService.sendItemInTransit("item-barcode"));
     assertThat(exception.getMessage(),
@@ -204,16 +197,13 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void changeStatusToAwaitingPickupSuccess() {
-    // given
     UUID mediatedRequestId = UUID.randomUUID();
     MediatedRequestEntity initialRequest = buildMediatedRequestEntity(OPEN_NOT_YET_FILLED)
       .withId(mediatedRequestId);
     when(mediatedRequestsRepository.save(mediatedRequestEntityCaptor.capture())).thenReturn(null);
 
-    // when
     mediatedRequestActionsService.changeStatusToAwaitingPickup(initialRequest);
 
-    // then
     MediatedRequestEntity updatedRequest = mediatedRequestEntityCaptor.getValue();
     assertNotNull(updatedRequest);
     assertEquals(MediatedRequestStatus.OPEN, updatedRequest.getMediatedRequestStatus());
@@ -330,16 +320,13 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void mediatedRequestDeclineWrongStatus() {
-    // given
     UUID mediatedRequestId = randomUUID();
-
     MediatedRequestEntity mediatedRequest = buildMediatedRequestEntity(OPEN_ITEM_ARRIVED)
       .withId(mediatedRequestId);
 
     when(mediatedRequestsRepository.findById(mediatedRequestId))
       .thenReturn(Optional.of(mediatedRequest));
 
-    // when-then
     RuntimeException exception = assertThrows(RuntimeException.class,
       () -> mediatedRequestActionsService.decline(mediatedRequestId));
     assertThat(exception.getMessage(),
@@ -348,19 +335,14 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void mediatedRequestDeclineSuccess() {
-    // given
     UUID mediatedRequestId = randomUUID();
-
     MediatedRequestEntity mediatedRequest = buildMediatedRequestEntity(NEW_AWAITING_CONFIRMATION)
       .withId(mediatedRequestId);
-
     when(mediatedRequestsRepository.findById(mediatedRequestId))
       .thenReturn(Optional.of(mediatedRequest));
 
-    // when
     mediatedRequestActionsService.decline(mediatedRequestId);
 
-    // then
     verify(mediatedRequestsRepository).save(
       mediatedRequest
         .withMediatedRequestStatus(MediatedRequestStatus.CLOSED)
@@ -372,16 +354,13 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void changeStatusToClosedFilled() {
-    // given
     UUID mediatedRequestId = UUID.randomUUID();
     MediatedRequestEntity initialRequest = buildMediatedRequestEntity(OPEN_NOT_YET_FILLED)
       .withId(mediatedRequestId);
     when(mediatedRequestsRepository.save(mediatedRequestEntityCaptor.capture())).thenReturn(null);
 
-    // when
     mediatedRequestActionsService.changeStatusToClosedFilled(initialRequest);
 
-    // then
     MediatedRequestEntity updatedRequest = mediatedRequestEntityCaptor.getValue();
     assertNotNull(updatedRequest);
     assertEquals(MediatedRequestStatus.CLOSED, updatedRequest.getMediatedRequestStatus());
@@ -391,7 +370,6 @@ class MediatedRequestActionsServiceTest {
 
   @Test
   void changeStatusToClosedCanceled() {
-    // given
     UUID mediatedRequestId = UUID.randomUUID();
     MediatedRequestEntity initialRequest = buildMediatedRequestEntity(OPEN_NOT_YET_FILLED)
       .withId(mediatedRequestId);
@@ -401,10 +379,8 @@ class MediatedRequestActionsServiceTest {
       .cancelledDate(new Date())
       .cancelledByUserId(UUID.randomUUID().toString());
 
-    // when
     mediatedRequestActionsService.changeStatusToClosedCanceled(initialRequest, request);
 
-    // then
     MediatedRequestEntity updatedRequest = mediatedRequestEntityCaptor.getValue();
     assertNotNull(updatedRequest);
     assertEquals(request.getCancellationReasonId(), updatedRequest.getCancellationReasonId().toString());

--- a/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
+++ b/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
@@ -378,8 +378,8 @@ class MediatedRequestActionsServiceTest {
     MediatedRequestEntity updatedRequest = mediatedRequestEntityCaptor.getValue();
     assertNotNull(updatedRequest);
     assertEquals(request.getCancellationReasonId(), updatedRequest.getCancellationReasonId().toString());
-    assertEquals(request.getCancellationReasonId(), updatedRequest.getCancellationReasonId().toString());
-    assertEquals(request.getCancellationReasonId(), updatedRequest.getCancellationReasonId().toString());
+    assertEquals(request.getCancelledDate(), updatedRequest.getCancelledDate());
+    assertEquals(request.getCancelledByUserId(), updatedRequest.getCancelledByUserId().toString());
     assertEquals(MediatedRequestStatus.CLOSED, updatedRequest.getMediatedRequestStatus());
     assertEquals(CLOSED_CANCELLED.getValue(), updatedRequest.getStatus());
     assertEquals(MediatedRequestStep.CANCELLED.getValue(), updatedRequest.getMediatedRequestStep());


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODREQMED-76

## Approach
Implementing handling of request status change to CLOSED_FILLED to update corresponding mediated request

#### TODOS and Open Questions

## Learning
