### PR TITLE
MODREQMED-105: Fetch item for in-transit slips from the lending tenant

### DIFF
--- a/src/main/java/org/folio/mr/controller/MediatedRequestActionsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestActionsController.java
@@ -110,8 +110,7 @@ public class MediatedRequestActionsController implements MediatedRequestsActions
     log.info("sendItemInTransit:: request={}", request);
     MediatedRequestContext context = actionsService.sendItemInTransit(request.getItemBarcode());
 
-    return ResponseEntity.ok(buildSendItemInTransitResponse(context,
-      logActionAndGetActionDate(context.getRequest())));
+    return ResponseEntity.ok(buildSendItemInTransitResponse(context));
   }
 
   private Date logActionAndGetActionDate(MediatedRequest request) {
@@ -121,12 +120,11 @@ public class MediatedRequestActionsController implements MediatedRequestsActions
     return actionsService.saveMediatedRequestWorkflowLog(request).getActionDate();
   }
 
-  private SendItemInTransitResponse buildSendItemInTransitResponse(MediatedRequestContext context,
-    Date inTransitDate) {
-
+  private SendItemInTransitResponse buildSendItemInTransitResponse(MediatedRequestContext context) {
     MediatedRequest request = context.getRequest();
     MediatedRequestItem item = request.getItem();
     MediatedRequestRequester requester = request.getRequester();
+    Date inTransitDate = logActionAndGetActionDate(context.getRequest());
 
     SendItemInTransitResponse response = new SendItemInTransitResponse()
       .inTransitDate(inTransitDate)

--- a/src/main/java/org/folio/mr/controller/MediatedRequestActionsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestActionsController.java
@@ -4,6 +4,7 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.folio.mr.domain.MediatedRequestContext;
 import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
 import org.folio.mr.domain.dto.ConfirmItemArrivalResponse;
 import org.folio.mr.domain.dto.ConfirmItemArrivalResponseInstance;
@@ -104,10 +105,10 @@ public class MediatedRequestActionsController implements MediatedRequestsActions
     SendItemInTransitRequest request) {
 
     log.info("sendItemInTransit:: request={}", request);
-    MediatedRequest mediatedRequest = actionsService.sendItemInTransit(request.getItemBarcode());
+    MediatedRequestContext context = actionsService.sendItemInTransit(request.getItemBarcode());
 
-    return ResponseEntity.ok(buildSendItemInTransitResponse(mediatedRequest,
-      logActionAndGetActionDate(mediatedRequest)));
+    return ResponseEntity.ok(buildSendItemInTransitResponse(context,
+      logActionAndGetActionDate(context.request())));
   }
 
   private Date logActionAndGetActionDate(MediatedRequest request) {
@@ -117,9 +118,10 @@ public class MediatedRequestActionsController implements MediatedRequestsActions
     return actionsService.saveMediatedRequestWorkflowLog(request).getActionDate();
   }
 
-  private SendItemInTransitResponse buildSendItemInTransitResponse(MediatedRequest request,
+  private SendItemInTransitResponse buildSendItemInTransitResponse(MediatedRequestContext context,
     Date inTransitDate) {
 
+    MediatedRequest request = context.request();
     MediatedRequestItem item = request.getItem();
     MediatedRequestRequester requester = request.getRequester();
 
@@ -136,7 +138,7 @@ public class MediatedRequestActionsController implements MediatedRequestsActions
         .chronology(item.getChronology())
         .displaySummary(item.getDisplaySummary())
         .copyNumber(item.getCopyNumber()))
-      .staffSlipContext(staffSlipContextService.createStaffSlipContext(request))
+      .staffSlipContext(staffSlipContextService.createStaffSlipContext(context))
       .mediatedRequest(new ConfirmItemArrivalResponseMediatedRequest()
         .id(UUID.fromString(request.getId()))
         .status(request.getStatus().getValue()))

--- a/src/main/java/org/folio/mr/domain/MediatedRequestContext.java
+++ b/src/main/java/org/folio/mr/domain/MediatedRequestContext.java
@@ -3,5 +3,21 @@ package org.folio.mr.domain;
 import org.folio.mr.domain.dto.Item;
 import org.folio.mr.domain.dto.MediatedRequest;
 
-public record MediatedRequestContext(MediatedRequest request, Item item) {
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+public final class MediatedRequestContext {
+  private final MediatedRequest request;
+  private Item item;
+  private String lendingTenantId;
 }

--- a/src/main/java/org/folio/mr/domain/MediatedRequestContext.java
+++ b/src/main/java/org/folio/mr/domain/MediatedRequestContext.java
@@ -1,0 +1,7 @@
+package org.folio.mr.domain;
+
+import org.folio.mr.domain.dto.Item;
+import org.folio.mr.domain.dto.MediatedRequest;
+
+public record MediatedRequestContext(MediatedRequest request, Item item) {
+}

--- a/src/main/java/org/folio/mr/service/MediatedRequestActionsService.java
+++ b/src/main/java/org/folio/mr/service/MediatedRequestActionsService.java
@@ -2,6 +2,7 @@ package org.folio.mr.service;
 
 import java.util.UUID;
 
+import org.folio.mr.domain.MediatedRequestContext;
 import org.folio.mr.domain.dto.MediatedRequest;
 import org.folio.mr.domain.dto.Request;
 import org.folio.mr.domain.entity.MediatedRequestEntity;
@@ -10,7 +11,7 @@ import org.folio.mr.domain.entity.MediatedRequestWorkflowLog;
 public interface MediatedRequestActionsService {
   void confirm(UUID mediatedRequestId);
   MediatedRequest confirmItemArrival(String itemBarcode);
-  MediatedRequest sendItemInTransit(String itemBarcode);
+  MediatedRequestContext sendItemInTransit(String itemBarcode);
   void decline(UUID mediatedRequestId);
   void changeStatusToInTransitForApproval(MediatedRequestEntity request);
   void changeStatusToAwaitingPickup(MediatedRequestEntity request);

--- a/src/main/java/org/folio/mr/service/impl/StaffSlipContextService.java
+++ b/src/main/java/org/folio/mr/service/impl/StaffSlipContextService.java
@@ -2,6 +2,8 @@ package org.folio.mr.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+
+import org.folio.mr.domain.MediatedRequestContext;
 import org.folio.mr.domain.dto.Instance;
 import org.folio.mr.domain.dto.InstanceContributorsInner;
 import org.folio.mr.domain.dto.Item;
@@ -21,12 +23,13 @@ public class StaffSlipContextService {
 
   private final InventoryService inventoryService;
 
-  public SendItemInTransitResponseStaffSlipContext createStaffSlipContext(MediatedRequest request) {
-    log.debug("createStaffSlipContext:: parameters request: {}", request);
+  public SendItemInTransitResponseStaffSlipContext createStaffSlipContext(MediatedRequestContext context) {
+
+    log.debug("createStaffSlipContext:: parameters context: {}", context);
 
     var staffSlipContextItem = new SendItemInTransitResponseStaffSlipContextItem();
+    Item item = context.item();
 
-    Item item = inventoryService.fetchItem(request.getItemId());
     if (item != null) {
       staffSlipContextItem
         .barcode(item.getBarcode())

--- a/src/main/java/org/folio/mr/service/impl/StaffSlipContextService.java
+++ b/src/main/java/org/folio/mr/service/impl/StaffSlipContextService.java
@@ -7,7 +7,6 @@ import org.folio.mr.domain.MediatedRequestContext;
 import org.folio.mr.domain.dto.Instance;
 import org.folio.mr.domain.dto.InstanceContributorsInner;
 import org.folio.mr.domain.dto.Item;
-import org.folio.mr.domain.dto.MediatedRequest;
 import org.folio.mr.domain.dto.SendItemInTransitResponseStaffSlipContext;
 import org.folio.mr.domain.dto.SendItemInTransitResponseStaffSlipContextItem;
 import org.folio.mr.service.InventoryService;
@@ -28,7 +27,7 @@ public class StaffSlipContextService {
     log.debug("createStaffSlipContext:: parameters context: {}", context);
 
     var staffSlipContextItem = new SendItemInTransitResponseStaffSlipContextItem();
-    Item item = context.item();
+    Item item = context.getItem();
 
     if (item != null) {
       staffSlipContextItem

--- a/src/main/java/org/folio/mr/service/impl/StaffSlipContextService.java
+++ b/src/main/java/org/folio/mr/service/impl/StaffSlipContextService.java
@@ -23,7 +23,6 @@ public class StaffSlipContextService {
   private final InventoryService inventoryService;
 
   public SendItemInTransitResponseStaffSlipContext createStaffSlipContext(MediatedRequestContext context) {
-
     log.debug("createStaffSlipContext:: parameters context: {}", context);
 
     var staffSlipContextItem = new SendItemInTransitResponseStaffSlipContextItem();

--- a/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
+++ b/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
@@ -80,6 +80,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
   private static final String SEARCH_ITEMS_URL = "/search/consortium/items";
   private static final String NOT_FOUND_ITEM_UUID = "f13ef24f-d0fe-4aa8-901a-bfad3f0e6cae";
   private static final String SEARCH_INSTANCES_URL = "/search/instances";
+  private static final String SEARCH_ITEM_URL = "/search/consortium/item";
 
   @Autowired
   private MediatedRequestsRepository mediatedRequestsRepository;
@@ -327,6 +328,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
   @SneakyThrows
   void successfulItemArrivalConfirmation() {
     MediatedRequestEntity request = createMediatedRequestEntity();
+    String itemId = request.getItemId().toString();
     String primaryRequestId = request.getConfirmedRequestId().toString();
     wireMockServer.stubFor(WireMock.get(urlMatching(CIRCULATION_REQUESTS_URL + "/" + primaryRequestId))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
@@ -336,6 +338,14 @@ class MediatedRequestActionsApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
       .willReturn(jsonResponse(new Request().id(primaryRequestId),
         HttpStatus.SC_OK)));
+
+    ConsortiumItem mockConsortiumItem = new ConsortiumItem()
+      .id(itemId)
+      .tenantId(TENANT_ID_COLLEGE);
+
+    wireMockServer.stubFor(WireMock.get(urlMatching(SEARCH_ITEM_URL + "/" + itemId))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CENTRAL))
+      .willReturn(jsonResponse(mockConsortiumItem, HttpStatus.SC_OK)));
 
     confirmItemArrival("A14837334314", request)
       .andExpect(status().isOk())
@@ -360,10 +370,9 @@ class MediatedRequestActionsApiTest extends BaseIT {
       .andExpect(jsonPath("requester.middleName", is("X")))
       .andExpect(jsonPath("requester.lastName", is("Mediated")));
 
-    wireMockServer.verify(1, getRequestedFor(urlPathMatching(SEARCH_INSTANCES_URL))
-      .withQueryParam("query", equalTo("id==" + request.getInstanceId()))
-      .withQueryParam("expandAll", equalTo("true"))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM)));
+    wireMockServer.verify(1, getRequestedFor(urlEqualTo(SEARCH_ITEM_URL + "/" + request.getItemId()))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CENTRAL)));
+
     wireMockServer.verify(1, getRequestedFor(urlEqualTo(ITEMS_URL + "/" + request.getItemId()))
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
 
@@ -433,6 +442,15 @@ class MediatedRequestActionsApiTest extends BaseIT {
     MediatedRequestEntity request = mediatedRequestsRepository.save(
       buildMediatedRequestEntity(OPEN_ITEM_ARRIVED)
     );
+
+    String itemId = request.getItemId().toString();
+    ConsortiumItem mockConsortiumItem = new ConsortiumItem()
+      .id(itemId)
+      .tenantId(TENANT_ID_COLLEGE);
+
+    wireMockServer.stubFor(WireMock.get(urlMatching(SEARCH_ITEM_URL + "/" + itemId))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CENTRAL))
+      .willReturn(jsonResponse(mockConsortiumItem, HttpStatus.SC_OK)));
 
     ResultActions resultActions = sendItemInTransit("A14837334314", request)
       .andExpect(status().isOk())

--- a/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
+++ b/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.moreThanOrExactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
@@ -81,6 +82,14 @@ class MediatedRequestActionsApiTest extends BaseIT {
   private static final String NOT_FOUND_ITEM_UUID = "f13ef24f-d0fe-4aa8-901a-bfad3f0e6cae";
   private static final String SEARCH_INSTANCES_URL = "/search/instances";
   private static final String SEARCH_ITEM_URL = "/search/consortium/item";
+  private static final String HOLDINGS_URL = "/holdings-storage/holdings";
+  private static final String MATERIAL_TYPES_URL = "/material-types";
+  private static final String LOAN_TYPES_URL = "/loan-types";
+  private static final String SERVICE_POINTS_URL = "/service-points";
+  private static final String LOCATIONS_URL = "/locations";
+  private static final String LIBRARIES_URL = "/location-units/libraries";
+  private static final String CAMPUSES_URL = "/location-units/campuses";
+  private static final String INSTITUTIONS_URL = "/location-units/institutions";
 
   @Autowired
   private MediatedRequestsRepository mediatedRequestsRepository;
@@ -474,6 +483,39 @@ class MediatedRequestActionsApiTest extends BaseIT {
       .andExpect(jsonPath("requester.firstName", is("Requester")))
       .andExpect(jsonPath("requester.middleName", is("X")))
       .andExpect(jsonPath("requester.lastName", is("Mediated")));
+
+    wireMockServer.verify(1, getRequestedFor(urlEqualTo(SEARCH_ITEM_URL + "/" + request.getItemId()))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CENTRAL)));
+
+    wireMockServer.verify(1, getRequestedFor(urlEqualTo(ITEMS_URL + "/" + request.getItemId()))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(1, getRequestedFor(urlEqualTo(INSTANCES_URL + "/" + request.getInstanceId()))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(1, getRequestedFor(urlEqualTo(HOLDINGS_URL + "/" + request.getHoldingsRecordId()))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(1, getRequestedFor(urlPathMatching(MATERIAL_TYPES_URL + ".*"))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(1, getRequestedFor(urlPathMatching(LOAN_TYPES_URL + ".*"))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(moreThanOrExactly(1), getRequestedFor(urlPathMatching(SERVICE_POINTS_URL + ".*"))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(1, getRequestedFor(urlPathMatching(LOCATIONS_URL + ".*"))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(1, getRequestedFor(urlPathMatching(LIBRARIES_URL + ".*"))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(1, getRequestedFor(urlPathMatching(CAMPUSES_URL + ".*"))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
+
+    wireMockServer.verify(1, getRequestedFor(urlPathMatching(INSTITUTIONS_URL + ".*"))
+      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_COLLEGE)));
 
     expectStaffSlipContext(resultActions);
 

--- a/src/test/java/org/folio/mr/controller/MediatedRequestActionsControllerTest.java
+++ b/src/test/java/org/folio/mr/controller/MediatedRequestActionsControllerTest.java
@@ -24,7 +24,6 @@ import org.folio.mr.domain.dto.ConfirmItemArrivalResponse;
 import org.folio.mr.domain.dto.MediatedRequest;
 import org.folio.mr.domain.dto.SendItemInTransitRequest;
 import org.folio.mr.domain.dto.SendItemInTransitResponse;
-import org.folio.mr.domain.dto.SendItemInTransitResponseStaffSlipContext;
 import org.folio.mr.domain.entity.MediatedRequestWorkflowLog;
 import org.folio.mr.service.MediatedRequestActionsService;
 import org.folio.mr.service.impl.StaffSlipContextService;
@@ -88,7 +87,7 @@ class MediatedRequestActionsControllerTest {
     when(mediatedRequestActionsService.saveMediatedRequestWorkflowLog(any()))
       .thenReturn(log);
     when(mediatedRequestActionsService.sendItemInTransit(any()))
-      .thenReturn(new MediatedRequestContext(mediatedRequest, null));
+      .thenReturn(new MediatedRequestContext(mediatedRequest));
 
     //when
     String barcode = mediatedRequest.getItem().getBarcode();
@@ -151,13 +150,11 @@ class MediatedRequestActionsControllerTest {
     MediatedRequestWorkflowLog log = buildMediatedRequestWorkflowLog(DATE_PATTERN, DATE);
     MediatedRequest mediatedRequest = buildMediatedRequest(OPEN_ITEM_ARRIVED);
     String itemBarcode = mediatedRequest.getItem().getBarcode();
-    MediatedRequestContext context = new MediatedRequestContext(mediatedRequest, null);
+    MediatedRequestContext context = new MediatedRequestContext(mediatedRequest);
     when(mediatedRequestActionsService.sendItemInTransit(itemBarcode))
       .thenReturn(context);
     when(mediatedRequestActionsService.saveMediatedRequestWorkflowLog(any()))
       .thenReturn(log);
-    when(staffSlipContextService.createStaffSlipContext(context))
-      .thenReturn(new SendItemInTransitResponseStaffSlipContext());
 
     // when
     var responseEntity = requestsController.sendItemInTransit(

--- a/src/test/java/org/folio/mr/controller/MediatedRequestActionsControllerTest.java
+++ b/src/test/java/org/folio/mr/controller/MediatedRequestActionsControllerTest.java
@@ -18,6 +18,7 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.folio.mr.domain.MediatedRequestContext;
 import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
 import org.folio.mr.domain.dto.ConfirmItemArrivalResponse;
 import org.folio.mr.domain.dto.MediatedRequest;
@@ -87,7 +88,7 @@ class MediatedRequestActionsControllerTest {
     when(mediatedRequestActionsService.saveMediatedRequestWorkflowLog(any()))
       .thenReturn(log);
     when(mediatedRequestActionsService.sendItemInTransit(any()))
-      .thenReturn(mediatedRequest);
+      .thenReturn(new MediatedRequestContext(mediatedRequest, null));
 
     //when
     String barcode = mediatedRequest.getItem().getBarcode();
@@ -150,11 +151,12 @@ class MediatedRequestActionsControllerTest {
     MediatedRequestWorkflowLog log = buildMediatedRequestWorkflowLog(DATE_PATTERN, DATE);
     MediatedRequest mediatedRequest = buildMediatedRequest(OPEN_ITEM_ARRIVED);
     String itemBarcode = mediatedRequest.getItem().getBarcode();
+    MediatedRequestContext context = new MediatedRequestContext(mediatedRequest, null);
     when(mediatedRequestActionsService.sendItemInTransit(itemBarcode))
-      .thenReturn(mediatedRequest);
+      .thenReturn(context);
     when(mediatedRequestActionsService.saveMediatedRequestWorkflowLog(any()))
       .thenReturn(log);
-    when(staffSlipContextService.createStaffSlipContext(mediatedRequest))
+    when(staffSlipContextService.createStaffSlipContext(context))
       .thenReturn(new SendItemInTransitResponseStaffSlipContext());
 
     // when

--- a/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
+++ b/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
@@ -146,8 +146,8 @@ class MediatedRequestActionsServiceTest {
     MediatedRequestContext result = mediatedRequestActionsService.sendItemInTransit(itemBarcode);
 
     verify(mediatedRequestsRepository).save(any(MediatedRequestEntity.class));
-    assertThat(result.request().getStatus().getValue(), is("Open - In transit to be checked out"));
-    assertThat(result.request().getMediatedRequestStep(), is("In transit to be checked out"));
+    assertThat(result.getRequest().getStatus().getValue(), is("Open - In transit to be checked out"));
+    assertThat(result.getRequest().getMediatedRequestStep(), is("In transit to be checked out"));
   }
 
   @Test

--- a/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
+++ b/src/test/java/org/folio/mr/service/MediatedRequestActionsServiceTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.folio.mr.client.SearchClient;
+import org.folio.mr.domain.MediatedRequestContext;
 import org.folio.mr.domain.MediatedRequestStatus;
 import org.folio.mr.domain.dto.ConsortiumItem;
 import org.folio.mr.domain.dto.EcsTlr;
@@ -142,11 +143,11 @@ class MediatedRequestActionsServiceTest {
     when(mediatedRequestMapper.mapEntityToDto(any(MediatedRequestEntity.class)))
       .thenReturn(mappedRequest);
 
-    MediatedRequest result = mediatedRequestActionsService.sendItemInTransit(itemBarcode);
+    MediatedRequestContext result = mediatedRequestActionsService.sendItemInTransit(itemBarcode);
 
     verify(mediatedRequestsRepository).save(any(MediatedRequestEntity.class));
-    assertThat(result.getStatus().getValue(), is("Open - In transit to be checked out"));
-    assertThat(result.getMediatedRequestStep(), is("In transit to be checked out"));
+    assertThat(result.request().getStatus().getValue(), is("Open - In transit to be checked out"));
+    assertThat(result.request().getMediatedRequestStep(), is("In transit to be checked out"));
   }
 
   @Test

--- a/src/test/java/org/folio/mr/service/StaffSlipContextServiceTest.java
+++ b/src/test/java/org/folio/mr/service/StaffSlipContextServiceTest.java
@@ -70,7 +70,7 @@ class StaffSlipContextServiceTest {
       .effectiveLocationId(locationId)
       .status(new ItemStatus().name(ItemStatus.NameEnum.AVAILABLE))
       .yearCaption(Set.of());
-    when(inventoryService.fetchItem(itemId)).thenReturn(item);
+
     when(inventoryService.fetchHolding(holdingId))
       .thenReturn(new HoldingsRecord().instanceId(instanceId));
     when(inventoryService.fetchInstance(instanceId))
@@ -142,7 +142,7 @@ class StaffSlipContextServiceTest {
       .effectiveLocationId(locationId)
       .status(new ItemStatus().name(ItemStatus.NameEnum.AVAILABLE))
       .yearCaption(Set.of());
-    when(inventoryService.fetchItem(itemId)).thenReturn(item);
+
     when(inventoryService.fetchHolding(holdingId)).thenReturn(null);
     when(inventoryService.fetchMaterialType(materialTypeId)).thenReturn(null);
     when(inventoryService.fetchLoanType(loanTypeId)).thenReturn(null);

--- a/src/test/java/org/folio/mr/service/StaffSlipContextServiceTest.java
+++ b/src/test/java/org/folio/mr/service/StaffSlipContextServiceTest.java
@@ -11,8 +11,6 @@ import org.folio.mr.domain.dto.Library;
 import org.folio.mr.domain.dto.LoanType;
 import org.folio.mr.domain.dto.Location;
 import org.folio.mr.domain.dto.MaterialType;
-import org.folio.mr.domain.dto.SearchInstance;
-import org.folio.mr.domain.dto.SearchItem;
 import org.folio.mr.domain.dto.ServicePoint;
 import org.folio.mr.service.impl.StaffSlipContextService;
 import org.junit.jupiter.api.Test;
@@ -22,7 +20,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 

--- a/src/test/java/org/folio/mr/service/StaffSlipContextServiceTest.java
+++ b/src/test/java/org/folio/mr/service/StaffSlipContextServiceTest.java
@@ -1,5 +1,6 @@
 package org.folio.mr.service;
 
+import org.folio.mr.domain.MediatedRequestContext;
 import org.folio.mr.domain.dto.Campus;
 import org.folio.mr.domain.dto.HoldingsRecord;
 import org.folio.mr.domain.dto.Instance;
@@ -10,6 +11,8 @@ import org.folio.mr.domain.dto.Library;
 import org.folio.mr.domain.dto.LoanType;
 import org.folio.mr.domain.dto.Location;
 import org.folio.mr.domain.dto.MaterialType;
+import org.folio.mr.domain.dto.SearchInstance;
+import org.folio.mr.domain.dto.SearchItem;
 import org.folio.mr.domain.dto.ServicePoint;
 import org.folio.mr.service.impl.StaffSlipContextService;
 import org.junit.jupiter.api.Test;
@@ -19,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -35,6 +39,9 @@ class StaffSlipContextServiceTest {
 
   @Mock
   private InventoryService inventoryService;
+
+  @Mock
+  private SearchService searchService;
 
   @InjectMocks
   private StaffSlipContextService staffSlipContextService;
@@ -94,12 +101,11 @@ class StaffSlipContextServiceTest {
     var request = buildMediatedRequest(OPEN_IN_TRANSIT_FOR_APPROVAL).itemId(itemId);
 
     // when
-    var result = staffSlipContextService.createStaffSlipContext(request);
+    var result = staffSlipContextService.createStaffSlipContext(new MediatedRequestContext(request, item));
 
     // then
     assertEquals("Available", result.getItem().getStatus());
 
-    verify(inventoryService).fetchItem(itemId);
     verify(inventoryService).fetchHolding(holdingId);
     verify(inventoryService).fetchInstance(instanceId);
     verify(inventoryService).fetchServicePoint(inTransitServicePointId);
@@ -157,13 +163,12 @@ class StaffSlipContextServiceTest {
     var request = buildMediatedRequest(OPEN_IN_TRANSIT_FOR_APPROVAL).itemId(itemId);
 
     // when
-    var result = staffSlipContextService.createStaffSlipContext(request);
+    var result = staffSlipContextService.createStaffSlipContext(new MediatedRequestContext(request, item));
 
     // then
     assertEquals("Available", result.getItem().getStatus());
     assertNull(result.getItem().getTitle());
 
-    verify(inventoryService).fetchItem(itemId);
     verify(inventoryService).fetchHolding(holdingId);
     verify(inventoryService).fetchServicePoint(inTransitServicePointId);
 

--- a/src/test/java/org/folio/mr/service/StaffSlipContextServiceTest.java
+++ b/src/test/java/org/folio/mr/service/StaffSlipContextServiceTest.java
@@ -98,7 +98,11 @@ class StaffSlipContextServiceTest {
     var request = buildMediatedRequest(OPEN_IN_TRANSIT_FOR_APPROVAL).itemId(itemId);
 
     // when
-    var result = staffSlipContextService.createStaffSlipContext(new MediatedRequestContext(request, item));
+    MediatedRequestContext context = MediatedRequestContext.builder()
+      .request(request)
+      .item(item)
+      .build();
+    var result = staffSlipContextService.createStaffSlipContext(context);
 
     // then
     assertEquals("Available", result.getItem().getStatus());
@@ -160,7 +164,11 @@ class StaffSlipContextServiceTest {
     var request = buildMediatedRequest(OPEN_IN_TRANSIT_FOR_APPROVAL).itemId(itemId);
 
     // when
-    var result = staffSlipContextService.createStaffSlipContext(new MediatedRequestContext(request, item));
+    MediatedRequestContext context = MediatedRequestContext.builder()
+      .request(request)
+      .item(item)
+      .build();
+    var result = staffSlipContextService.createStaffSlipContext(context);
 
     // then
     assertEquals("Available", result.getItem().getStatus());

--- a/src/test/java/org/folio/mr/util/TestEntityBuilder.java
+++ b/src/test/java/org/folio/mr/util/TestEntityBuilder.java
@@ -36,6 +36,7 @@ public class TestEntityBuilder {
       .withFulfillmentPreference(FulfillmentPreference.DELIVERY)
       .withInstanceId(UUID.fromString("69640328-788e-43fc-9c3c-af39e243f3b7"))
       .withInstanceTitle("ABA Journal")
+      .withHoldingsRecordId(UUID.fromString("0c45bb50-7c9b-48b0-86eb-178a494e25fe"))
       .withItemId(UUID.fromString("9428231b-dd31-4f70-8406-fe22fbdeabc2"))
       .withItemBarcode("A14837334314")
       .withConfirmedRequestId(UUID.randomUUID())


### PR DESCRIPTION
## Purpose
In order to build in-transit slip for a mediated request, the requested item is currently fetched from the local ("secure") tenant. This is incorrect, because the item is located in another data-tenant. Item must be fetched from the lending tenant
Resolves [](https://folio-org.atlassian.net/browse/MODREQMED-105)

## Approach
Find item home-tenant through search. Fetch item from that tenant's inventory, while avoiding fetching it twice.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
