### PR TITLE
MODREQMED-111: Circulation requests for oLOAN Items not routing to Mediated requests app

### DIFF
--- a/src/main/java/org/folio/mr/service/impl/RequestEventHandler.java
+++ b/src/main/java/org/folio/mr/service/impl/RequestEventHandler.java
@@ -69,7 +69,7 @@ public class RequestEventHandler implements KafkaEventHandler<Request> {
 
     Request.EcsRequestPhaseEnum ecsRequestPhase = newRequest.getEcsRequestPhase();
     log.info("handleRequestUpdateEvent:: updated request ECS phase: {}", ecsRequestPhase);
-    if (ecsRequestPhase != PRIMARY) {
+    if (ecsRequestPhase != null && ecsRequestPhase != PRIMARY) {
       log.info("handleRequestUpdateEvent:: ignoring non-primary request");
       return;
     }

--- a/src/test/java/org/folio/mr/controller/KafkaEventListenerTest.java
+++ b/src/test/java/org/folio/mr/controller/KafkaEventListenerTest.java
@@ -96,8 +96,8 @@ class KafkaEventListenerTest extends BaseIT {
     KafkaEvent<Request> event = buildLocalRequestUpdateEvent(OPEN_NOT_YET_FILLED, OPEN_IN_TRANSIT);
     var mediatedRequest = buildMediatedRequest(MediatedRequest.StatusEnum.OPEN_NOT_YET_FILLED);
     mediatedRequest.setConfirmedRequestId(CONFIRMED_REQUEST_ID.toString());
-    var initialMediatedRequest =
-      createMediatedRequest(mediatedRequestMapper.mapDtoToEntity(mediatedRequest));
+    var initialMediatedRequest = createMediatedRequest(mediatedRequestMapper.mapDtoToEntity(
+      mediatedRequest));
     assertNotNull(initialMediatedRequest.getId());
 
     publishEventAndWait(TENANT_ID_CONSORTIUM, REQUEST_KAFKA_TOPIC_NAME, event);


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODREQMED-111

## Approach
ecsREquestPhase is null for local secure requests. Updated RequestEventHandler to properly handle this case.

#### TODOS and Open Questions

## Learning
