### PR TITLE
MODREQMED-116: Handle empty user addresses

### DIFF
--- a/src/main/java/org/folio/mr/controller/MediatedRequestActionsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestActionsController.java
@@ -1,8 +1,10 @@
 package org.folio.mr.controller;
 
 import static java.util.Optional.ofNullable;
+import static java.util.function.Predicate.not;
 
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import org.folio.mr.domain.MediatedRequestContext;
@@ -22,6 +24,7 @@ import org.folio.mr.domain.dto.SendItemInTransitResponse;
 import org.folio.mr.domain.dto.SendItemInTransitResponseRequester;
 import org.folio.mr.domain.dto.SendItemInTransitResponseStaffSlipContext;
 import org.folio.mr.domain.dto.User;
+import org.folio.mr.domain.dto.UserPersonal;
 import org.folio.mr.rest.resource.MediatedRequestsActionsApi;
 import org.folio.mr.service.MediatedRequestActionsService;
 import org.folio.mr.service.impl.StaffSlipContextService;
@@ -156,7 +159,9 @@ public class MediatedRequestActionsController implements MediatedRequestsActions
 
     ofNullable(user)
       .map(User::getPersonal)
-      .map(personal -> personal.getAddresses().getFirst())
+      .map(UserPersonal::getAddresses)
+      .filter(not(List::isEmpty))
+      .map(List::getFirst)
       .ifPresent(address ->
         response.getRequester()
           .addressLine1(address.getAddressLine1())


### PR DESCRIPTION
## Purpose
Avoid `NoSuchElementException` when building staff slip context for a user with no addresses.
Follows #85, resolves [MODREQMED-116](https://folio-org.atlassian.net/browse/MODREQMED-116)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
