### PR TITLE
MODREQMED-116: Remove usage of method introduced in Java 21

### DIFF
--- a/src/main/java/org/folio/mr/controller/MediatedRequestActionsController.java
+++ b/src/main/java/org/folio/mr/controller/MediatedRequestActionsController.java
@@ -1,11 +1,11 @@
 package org.folio.mr.controller;
 
 import static java.util.Optional.ofNullable;
-import static java.util.function.Predicate.not;
 
+import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.folio.mr.domain.MediatedRequestContext;
 import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
@@ -160,8 +160,8 @@ public class MediatedRequestActionsController implements MediatedRequestsActions
     ofNullable(user)
       .map(User::getPersonal)
       .map(UserPersonal::getAddresses)
-      .filter(not(List::isEmpty))
-      .map(List::getFirst)
+      .map(Collection::stream)
+      .flatMap(Stream::findFirst)
       .ifPresent(address ->
         response.getRequester()
           .addressLine1(address.getAddressLine1())


### PR DESCRIPTION
## Purpose
Remove usage of method `List#getFirst` introduced in Java 21 and replace it with approach compatible with Java 17. [MODREQMED-116](https://folio-org.atlassian.net/browse/MODREQMED-116) must be included in Ramsons (R2 2024) release which is built on Java 17.

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
