### PR TITLE
MODREQMED-127 Support for Open - Awaiting delivery status

### DIFF
--- a/src/main/java/org/folio/mr/service/MediatedRequestActionsService.java
+++ b/src/main/java/org/folio/mr/service/MediatedRequestActionsService.java
@@ -15,6 +15,7 @@ public interface MediatedRequestActionsService {
   void decline(UUID mediatedRequestId);
   void changeStatusToInTransitForApproval(MediatedRequestEntity request);
   void changeStatusToAwaitingPickup(MediatedRequestEntity request);
+  void changeStatusToAwaitingDelivery(MediatedRequestEntity request);
   void changeStatusToClosedFilled(MediatedRequestEntity request);
   void changeStatusToClosedCanceled(MediatedRequestEntity mediatedRequest, Request confirmedRequest);
   MediatedRequestWorkflowLog saveMediatedRequestWorkflowLog(MediatedRequest request);

--- a/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
+++ b/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
@@ -5,6 +5,7 @@ import static java.util.Optional.ofNullable;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.CLOSED_CANCELLED;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.CLOSED_DECLINED;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.CLOSED_FILLED;
+import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_AWAITING_DELIVERY;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_AWAITING_PICKUP;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_IN_TRANSIT_FOR_APPROVAL;
 import static org.folio.mr.domain.dto.MediatedRequest.StatusEnum.OPEN_IN_TRANSIT_TO_BE_CHECKED_OUT;
@@ -393,6 +394,12 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
   public void changeStatusToAwaitingPickup(MediatedRequestEntity request) {
     log.info("changeStatusToAwaitingPickup:: request id: {}", request.getId());
     changeMediatedRequestStatus(request, OPEN_AWAITING_PICKUP);
+  }
+
+  @Override
+  public void changeStatusToAwaitingDelivery(MediatedRequestEntity request) {
+    log.info("changeStatusToAwaitingDelivery:: request id: {}", request.getId());
+    changeMediatedRequestStatus(request, OPEN_AWAITING_DELIVERY);
   }
 
   @Override

--- a/src/main/java/org/folio/mr/service/impl/RequestEventHandler.java
+++ b/src/main/java/org/folio/mr/service/impl/RequestEventHandler.java
@@ -105,11 +105,16 @@ public class RequestEventHandler implements KafkaEventHandler<Request> {
       actionsService.changeStatusToInTransitForApproval(mediatedRequest);
       wasMediatedRequestUpdated = true;
     }
-    if ((newRequestStatus == OPEN_AWAITING_PICKUP || newRequestStatus == OPEN_AWAITING_DELIVERY) &&
-      oldRequestStatus == OPEN_IN_TRANSIT &&
+    if (newRequestStatus == OPEN_AWAITING_PICKUP && oldRequestStatus == OPEN_IN_TRANSIT &&
       mediatedRequestStatusEquals(mediatedRequest, OPEN, IN_TRANSIT_TO_BE_CHECKED_OUT)
     ) {
       actionsService.changeStatusToAwaitingPickup(mediatedRequest);
+      wasMediatedRequestUpdated = true;
+    }
+    if (newRequestStatus == OPEN_AWAITING_DELIVERY && oldRequestStatus == OPEN_IN_TRANSIT &&
+      mediatedRequestStatusEquals(mediatedRequest, OPEN, IN_TRANSIT_TO_BE_CHECKED_OUT)
+    ) {
+      actionsService.changeStatusToAwaitingDelivery(mediatedRequest);
       wasMediatedRequestUpdated = true;
     }
     if (newRequestStatus == CLOSED_FILLED &&

--- a/src/main/resources/swagger.api/schemas/mediatedRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/mediatedRequest.yaml
@@ -237,7 +237,7 @@ MediatedRequest:
       type: string
       enum: [ 'New - Awaiting confirmation', 'Open - Not yet filled', 'Open - In transit for approval',
               'Open - Item arrived', 'Open - In transit to be checked out', 'Open - Awaiting pickup',
-              'Closed - Cancelled', 'Closed - Declined', 'Closed - Filled'
+              'Open - Awaiting delivery', 'Closed - Cancelled', 'Closed - Declined', 'Closed - Filled'
       ]
     cancellationReasonId:
       description: ID of the cancellation reason


### PR DESCRIPTION
## Purpose
[MODREQMED-127 Support for Open - Awaiting delivery status](https://folio-org.atlassian.net/browse/MODREQMED-127)

## Approach
Handle request update event differently. Currently it is updating mediated request status to `Open - Awaiting pickup` even when primary request status changed to `Open - Awaiting delivery`.
