### PR TITLE
MODREQMED-224: Do not throw an exception when item is not found 

### DIFF
--- a/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
+++ b/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
@@ -298,8 +298,7 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
   }
 
   private void findItem(MediatedRequestContext context) {
-    String itemId = context.getRequest().getItemId();
-    searchService.searchItem(itemId)
+    searchService.searchItem(context.getRequest().getItemId())
       .map(ConsortiumItem::getTenantId)
       .map(context::setLendingTenantId)
       .ifPresent(this::fetchItem);

--- a/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
+++ b/src/main/java/org/folio/mr/service/impl/MediatedRequestActionsServiceImpl.java
@@ -299,11 +299,10 @@ public class MediatedRequestActionsServiceImpl implements MediatedRequestActions
 
   private void findItem(MediatedRequestContext context) {
     String itemId = context.getRequest().getItemId();
-    var searchItem = searchService.searchItem(itemId)
-      .orElseThrow(() -> ExceptionFactory.notFound(format("Item %s not found", itemId)));
-
-    context.setLendingTenantId(searchItem.getTenantId());
-    fetchItem(context);
+    searchService.searchItem(itemId)
+      .map(ConsortiumItem::getTenantId)
+      .map(context::setLendingTenantId)
+      .ifPresent(this::fetchItem);
   }
 
   private void findRequester(MediatedRequestContext context) {

--- a/src/test/java/org/folio/mr/api/CheckOutApiTest.java
+++ b/src/test/java/org/folio/mr/api/CheckOutApiTest.java
@@ -90,7 +90,7 @@ class CheckOutApiTest extends BaseIT {
       buildItemBatchSearchResponse(ITEM_BARCODE, TENANT_ID_COLLEGE));
 
     // mock secondary request
-    mockHelper.mockGetRequest(buildRequest(mediatedRequest, FAKE_USER_BARCODE), TENANT_ID_COLLEGE);
+    mockHelper.mockGetRequestFromStorage(buildRequest(mediatedRequest, FAKE_USER_BARCODE), TENANT_ID_COLLEGE);
 
     // mock check-out dry run
     mockHelper.mockCirculationCheckOutDryRun(
@@ -157,7 +157,7 @@ class CheckOutApiTest extends BaseIT {
       buildItemBatchSearchResponse(ITEM_BARCODE, TENANT_ID_COLLEGE));
 
     // mock secondary request
-    mockHelper.mockGetRequest(buildRequest(mediatedRequest, FAKE_USER_BARCODE), TENANT_ID_COLLEGE);
+    mockHelper.mockGetRequestFromStorage(buildRequest(mediatedRequest, FAKE_USER_BARCODE), TENANT_ID_COLLEGE);
 
     // mock check-out dry run
     mockHelper.mockCirculationCheckOutDryRun(
@@ -327,7 +327,7 @@ class CheckOutApiTest extends BaseIT {
     mockHelper.mockItemBatchSearch(TENANT_ID_CENTRAL, buildBatchIds(),
       buildItemBatchSearchResponse(ITEM_BARCODE, TENANT_ID_COLLEGE));
 
-    mockHelper.mockGetRequest(buildRequest(mediatedRequest, FAKE_USER_BARCODE), TENANT_ID_COLLEGE);
+    mockHelper.mockGetRequestFromStorage(buildRequest(mediatedRequest, FAKE_USER_BARCODE), TENANT_ID_COLLEGE);
 
     wireMockServer.stubFor(post(urlEqualTo(CIRCULATION_CHECK_OUT_DRY_RUN_URL))
       .withRequestBody(equalToJson(asJsonString(buildCheckOutDryRunRequest(FAKE_USER_BARCODE, ITEM_BARCODE))))
@@ -363,7 +363,7 @@ class CheckOutApiTest extends BaseIT {
     mockHelper.mockItemBatchSearch(TENANT_ID_CENTRAL, buildBatchIds(),
       buildItemBatchSearchResponse(ITEM_BARCODE, TENANT_ID_COLLEGE));
 
-    mockHelper.mockGetRequest(buildRequest(mediatedRequest, FAKE_USER_BARCODE), TENANT_ID_COLLEGE);
+    mockHelper.mockGetRequestFromStorage(buildRequest(mediatedRequest, FAKE_USER_BARCODE), TENANT_ID_COLLEGE);
 
     mockHelper.mockCirculationCheckOutDryRun(
       buildCheckOutDryRunRequest(FAKE_USER_BARCODE, ITEM_BARCODE),

--- a/src/test/java/org/folio/mr/api/ClaimItemReturnedApiTest.java
+++ b/src/test/java/org/folio/mr/api/ClaimItemReturnedApiTest.java
@@ -60,7 +60,7 @@ class ClaimItemReturnedApiTest extends BaseIT {
         .withRequesterId(userId)
         .withConfirmedRequestId(confirmedRequestId));
 
-    mockHelper.mockGetRequest(new Request()
+    mockHelper.mockGetRequestFromStorage(new Request()
       .id(confirmedRequestId.toString())
       .requesterId(fakeRequesterId.toString()), TENANT_ID_CENTRAL);
 

--- a/src/test/java/org/folio/mr/api/DeclareClaimedReturnedItemAsMissingApiTest.java
+++ b/src/test/java/org/folio/mr/api/DeclareClaimedReturnedItemAsMissingApiTest.java
@@ -44,7 +44,7 @@ class DeclareClaimedReturnedItemAsMissingApiTest extends BaseIT {
     mockHelper.mockPostNoContentResponse(CIRCULATION_DECLARE_MISSING_URL, TENANT_ID_CONSORTIUM);
     mockHelper.mockGetLoan(buildLoan(), TENANT_ID_CONSORTIUM);
     mediatedRequestsRepository.save(buildMediatedRequest());
-    mockHelper.mockGetRequest(buildCentalTenantRequest(), TENANT_ID_CENTRAL);
+    mockHelper.mockGetRequestFromStorage(buildCentalTenantRequest(), TENANT_ID_CENTRAL);
     mockHelper.mockPostNoContentResponse(TLR_DECLARE_MISSING_URL, TENANT_ID_CENTRAL);
 
     declareItemMissing()

--- a/src/test/java/org/folio/mr/api/DeclareLostApiTest.java
+++ b/src/test/java/org/folio/mr/api/DeclareLostApiTest.java
@@ -60,7 +60,7 @@ class DeclareLostApiTest extends BaseIT {
         .withRequesterId(userId)
         .withConfirmedRequestId(confirmedRequestId));
 
-    mockHelper.mockGetRequest(new Request()
+    mockHelper.mockGetRequestFromStorage(new Request()
       .id(confirmedRequestId.toString())
       .requesterId(fakeRequesterId.toString()), TENANT_ID_CENTRAL);
 

--- a/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
+++ b/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
@@ -449,9 +449,10 @@ class MediatedRequestActionsApiTest extends BaseIT {
     MediatedRequestEntity request = createMediatedRequestEntity();
     String itemId = request.getItemId().toString();
 
-    Request mockConfirmedRequest = new Request().id(request.getConfirmedRequestId().toString());
-    mockHelper.mockGetRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
-    mockHelper.mockPutRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
+    String confirmedRequestId = request.getConfirmedRequestId().toString();
+    Request confirmedRequest = new Request().id(confirmedRequestId);
+    mockHelper.mockGetRequest(confirmedRequest, TENANT_ID_CONSORTIUM);
+    mockHelper.mockPutRequest(confirmedRequestId, TENANT_ID_CONSORTIUM);
 
     ConsortiumItem mockConsortiumItem = new ConsortiumItem()
       .id(itemId)
@@ -525,9 +526,10 @@ class MediatedRequestActionsApiTest extends BaseIT {
   void itemArrivalConfirmationDoesNotFailWhenItemIsNotFound() {
     var request = mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_IN_TRANSIT_FOR_APPROVAL)
       .withItemId(UUID.fromString(NOT_FOUND_ITEM_UUID)));
-    Request mockConfirmedRequest = new Request().id(request.getConfirmedRequestId().toString());
+    String confirmedRequestId = request.getConfirmedRequestId().toString();
+    Request mockConfirmedRequest = new Request().id(confirmedRequestId);
     mockHelper.mockGetRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
-    mockHelper.mockPutRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
+    mockHelper.mockPutRequest(confirmedRequestId, TENANT_ID_CONSORTIUM);
     mockHelper.mockItemSearchNotFound(TENANT_ID_CONSORTIUM, NOT_FOUND_ITEM_UUID);
     confirmItemArrival("A14837334314").andExpect(status().isOk());
   }

--- a/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
+++ b/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
@@ -29,10 +29,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
 import org.apache.http.HttpStatus;
 import org.folio.mr.domain.MediatedRequestStatus;
 import org.folio.mr.domain.dto.ConfirmItemArrivalRequest;
@@ -45,9 +45,6 @@ import org.folio.mr.domain.dto.Items;
 import org.folio.mr.domain.dto.MediatedRequest;
 import org.folio.mr.domain.dto.Request;
 import org.folio.mr.domain.dto.RequestItem;
-import org.folio.mr.domain.dto.SearchInstance;
-import org.folio.mr.domain.dto.SearchInstancesResponse;
-import org.folio.mr.domain.dto.SearchItem;
 import org.folio.mr.domain.dto.SendItemInTransitRequest;
 import org.folio.mr.domain.dto.User;
 import org.folio.mr.domain.entity.MediatedRequestEntity;
@@ -57,14 +54,13 @@ import org.folio.mr.repository.MediatedRequestsRepository;
 import org.folio.test.types.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.SneakyThrows;
 
 @IntegrationTest
@@ -453,15 +449,10 @@ class MediatedRequestActionsApiTest extends BaseIT {
   void successfulItemArrivalConfirmation() {
     MediatedRequestEntity request = createMediatedRequestEntity();
     String itemId = request.getItemId().toString();
-    String primaryRequestId = request.getConfirmedRequestId().toString();
-    wireMockServer.stubFor(WireMock.get(urlMatching(CIRCULATION_REQUESTS_URL + "/" + primaryRequestId))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(new Request().id(primaryRequestId),
-        HttpStatus.SC_OK)));
-    wireMockServer.stubFor(WireMock.put(urlMatching(CIRCULATION_REQUESTS_URL + "/" + primaryRequestId))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(new Request().id(primaryRequestId),
-        HttpStatus.SC_OK)));
+
+    Request mockConfirmedRequest = new Request().id(request.getConfirmedRequestId().toString());
+    mockHelper.mockGetRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
+    mockHelper.mockPutRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
 
     ConsortiumItem mockConsortiumItem = new ConsortiumItem()
       .id(itemId)
@@ -471,7 +462,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CENTRAL))
       .willReturn(jsonResponse(mockConsortiumItem, HttpStatus.SC_OK)));
 
-    confirmItemArrival("A14837334314", request)
+    confirmItemArrival("A14837334314")
       .andExpect(status().isOk())
       .andExpect(jsonPath("arrivalDate", notNullValue()))
       .andExpect(jsonPath("instance.id", is("69640328-788e-43fc-9c3c-af39e243f3b7")))
@@ -509,9 +500,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
   @Test
   @SneakyThrows
   void itemArrivalConfirmationFailsWhenMediatedRequestIsNotFoundByItemBarcode() {
-    confirmItemArrival("random-barcode", new MediatedRequestEntity()
-      .withInstanceId(UUID.randomUUID())
-      .withItemId(UUID.randomUUID()))
+    confirmItemArrival("random-barcode")
       .andExpect(status().isNotFound())
       .andExpect(jsonPath("errors").value(iterableWithSize(1)))
       .andExpect(errorTypeMatch(is(NOT_FOUND_ERROR.getValue())))
@@ -525,7 +514,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
     MediatedRequestEntity mediatedRequest = mediatedRequestsRepository.save(
       buildMediatedRequestEntity(OPEN_ITEM_ARRIVED));// wrong status
 
-    confirmItemArrival("A14837334314", mediatedRequest)
+    confirmItemArrival("A14837334314")
       .andExpect(status().isNotFound())
       .andExpect(jsonPath("errors").value(iterableWithSize(1)))
       .andExpect(errorTypeMatch(is(NOT_FOUND_ERROR.getValue())))
@@ -533,26 +522,26 @@ class MediatedRequestActionsApiTest extends BaseIT {
         is("Mediated request for arrival confirmation of item with barcode 'A14837334314' was not found")));
   }
 
+  @SneakyThrows
+  @Test
+  void itemArrivalConfirmationDoesNotFailWhenItemIsNotFound() {
+    var request = mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_IN_TRANSIT_FOR_APPROVAL)
+      .withItemId(UUID.fromString(NOT_FOUND_ITEM_UUID)));
+    mockHelper.mockItemSearchNotFound(TENANT_ID_CONSORTIUM, NOT_FOUND_ITEM_UUID);
+
+    Request mockConfirmedRequest = new Request().id(request.getConfirmedRequestId().toString());
+    mockHelper.mockGetRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
+    mockHelper.mockPutRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
+
+    confirmItemArrival("A14837334314").andExpect(status().isOk());
+  }
+
   private MediatedRequestEntity createMediatedRequestEntity() {
     return mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_IN_TRANSIT_FOR_APPROVAL));
   }
 
   @SneakyThrows
-  private ResultActions confirmItemArrival(String itemBarcode, MediatedRequestEntity request) {
-    var instanceId = request.getInstanceId().toString();
-    wireMockServer.stubFor(WireMock.get(urlPathMatching(SEARCH_INSTANCES_URL))
-      .withQueryParam("query", equalTo("id==" + instanceId))
-      .withQueryParam("expandAll", equalTo("true"))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(new SearchInstancesResponse().addInstancesItem(
-          new SearchInstance()
-            .id(instanceId)
-            .tenantId(TENANT_ID_CONSORTIUM)
-            .addItemsItem(new SearchItem()
-              .id(request.getItemId().toString())
-              .tenantId(TENANT_ID_COLLEGE))),
-        HttpStatus.SC_OK)));
-
+  private ResultActions confirmItemArrival(String itemBarcode) {
     return mockMvc.perform(
       post(CONFIRM_ITEM_ARRIVAL_URL)
         .headers(defaultHeaders())
@@ -576,7 +565,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
       .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CENTRAL))
       .willReturn(jsonResponse(mockConsortiumItem, HttpStatus.SC_OK)));
 
-    ResultActions resultActions = sendItemInTransit("A14837334314", request)
+    ResultActions resultActions = sendItemInTransit("A14837334314")
       .andExpect(status().isOk())
       .andExpect(jsonPath("inTransitDate", notNullValue()))
       .andExpect(jsonPath("instance.id", is("69640328-788e-43fc-9c3c-af39e243f3b7")))
@@ -669,74 +658,19 @@ class MediatedRequestActionsApiTest extends BaseIT {
       .andExpect(jsonPath("staffSlipContext.item.toServicePoint", is("Circ Desk 1")));
   }
 
+  @SneakyThrows
   @Test
-  @SneakyThrows
-  void sendItemInTransitItemNotFound() {
-    MediatedRequestEntity request = mediatedRequestsRepository.save(
-      buildMediatedRequestEntity(OPEN_ITEM_ARRIVED).withItemId(UUID.fromString(NOT_FOUND_ITEM_UUID))
-    );
-
-    sendItemInTransit("A14837334314", request).andExpect(status().isNotFound());
-  }
-
-  @SneakyThrows
-  @ParameterizedTest
-  @NullAndEmptySource
-  void sendItemInTransitShouldReturnNotFoundIfNoSearchInstancesFound(List<SearchInstance> instances) {
+  void sendItemInTransitDoesNotFailWhenItemIsNotFound() {
     var request = mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_ITEM_ARRIVED)
       .withItemId(UUID.fromString(NOT_FOUND_ITEM_UUID)));
-
-    var instanceId = request.getInstanceId().toString();
-    wireMockServer.stubFor(WireMock.get(urlPathMatching(SEARCH_INSTANCES_URL))
-      .withQueryParam("query", equalTo("id==" + instanceId))
-      .withQueryParam("expandAll", equalTo("true"))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(new SearchInstancesResponse().instances(instances), HttpStatus.SC_OK)));
-
-    mockMvc.perform(
-      post(SEND_ITEM_IN_TRANSIT_URL)
-        .headers(defaultHeaders())
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(asJsonString(new SendItemInTransitRequest()
-          .itemBarcode(request.getItemBarcode()))));
-
-    sendItemInTransit("A14837334314", request).andExpect(status().isNotFound());
-  }
-
-  @SneakyThrows
-  @ParameterizedTest
-  @NullAndEmptySource
-  void sendItemInTransitShouldReturnNotFoundIfNoSearchItemsFound(List<SearchItem> items) {
-    var request = mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_ITEM_ARRIVED)
-      .withItemId(UUID.fromString(NOT_FOUND_ITEM_UUID)));
-
-    var instanceId = request.getInstanceId().toString();
-    wireMockServer.stubFor(WireMock.get(urlPathMatching(SEARCH_INSTANCES_URL))
-      .withQueryParam("query", equalTo("id==" + instanceId))
-      .withQueryParam("expandAll", equalTo("true"))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(new SearchInstancesResponse().instances(
-        List.of(new SearchInstance().id(instanceId)
-          .tenantId(TENANT_ID_CONSORTIUM)
-          .items(items))), HttpStatus.SC_OK)));
-
-    mockMvc.perform(
-      post(SEND_ITEM_IN_TRANSIT_URL)
-        .headers(defaultHeaders())
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(asJsonString(new SendItemInTransitRequest()
-          .itemBarcode(request.getItemBarcode()))));
-
-    sendItemInTransit("A14837334314", request).andExpect(status().isNotFound());
+    mockHelper.mockItemSearchNotFound(TENANT_ID_CONSORTIUM, NOT_FOUND_ITEM_UUID);
+    sendItemInTransit("A14837334314").andExpect(status().isOk());
   }
 
   @Test
   @SneakyThrows
   void sendItemInTransitFailsWhenMediatedRequestIsNotFoundByItemBarcode() {
-    sendItemInTransit("random-barcode", new MediatedRequestEntity()
-      .withInstanceId(UUID.randomUUID())
-      .withItemId(UUID.randomUUID()))
-      .andExpect(status().isNotFound())
+    sendItemInTransit("random-barcode")
       .andExpect(jsonPath("errors").value(iterableWithSize(1)))
       .andExpect(errorTypeMatch(is(NOT_FOUND_ERROR.getValue())))
       .andExpect(errorMessageMatch(
@@ -749,7 +683,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
     MediatedRequestEntity request = mediatedRequestsRepository.save(
       buildMediatedRequestEntity(OPEN_IN_TRANSIT_TO_BE_CHECKED_OUT));// wrong status
 
-    sendItemInTransit("A14837334314", request)
+    sendItemInTransit("A14837334314")
       .andExpect(status().isNotFound())
       .andExpect(jsonPath("errors").value(iterableWithSize(1)))
       .andExpect(errorTypeMatch(is(NOT_FOUND_ERROR.getValue())))
@@ -758,21 +692,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
   }
 
   @SneakyThrows
-  private ResultActions sendItemInTransit(String itemBarcode, MediatedRequestEntity request) {
-    var instanceId = request.getInstanceId().toString();
-    wireMockServer.stubFor(WireMock.get(urlPathMatching(SEARCH_INSTANCES_URL))
-      .withQueryParam("query", equalTo("id==" + instanceId))
-      .withQueryParam("expandAll", equalTo("true"))
-      .withHeader(HEADER_TENANT, equalTo(TENANT_ID_CONSORTIUM))
-      .willReturn(jsonResponse(new SearchInstancesResponse().addInstancesItem(
-          new SearchInstance()
-            .id(instanceId)
-            .tenantId(TENANT_ID_CONSORTIUM)
-            .addItemsItem(new SearchItem()
-              .id(request.getItemId().toString())
-              .tenantId(TENANT_ID_COLLEGE))),
-        HttpStatus.SC_OK)));
-
+  private ResultActions sendItemInTransit(String itemBarcode) {
     return mockMvc.perform(
       post(SEND_ITEM_IN_TRANSIT_URL)
         .headers(defaultHeaders())

--- a/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
+++ b/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
@@ -525,12 +525,10 @@ class MediatedRequestActionsApiTest extends BaseIT {
   void itemArrivalConfirmationDoesNotFailWhenItemIsNotFound() {
     var request = mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_IN_TRANSIT_FOR_APPROVAL)
       .withItemId(UUID.fromString(NOT_FOUND_ITEM_UUID)));
-    mockHelper.mockItemSearchNotFound(TENANT_ID_CONSORTIUM, NOT_FOUND_ITEM_UUID);
-
     Request mockConfirmedRequest = new Request().id(request.getConfirmedRequestId().toString());
     mockHelper.mockGetRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
     mockHelper.mockPutRequest(mockConfirmedRequest, TENANT_ID_CONSORTIUM);
-
+    mockHelper.mockItemSearchNotFound(TENANT_ID_CONSORTIUM, NOT_FOUND_ITEM_UUID);
     confirmItemArrival("A14837334314").andExpect(status().isOk());
   }
 

--- a/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
+++ b/src/test/java/org/folio/mr/api/MediatedRequestActionsApiTest.java
@@ -80,7 +80,6 @@ class MediatedRequestActionsApiTest extends BaseIT {
   private static final String ECS_TLR_URL = "/tlr/ecs-tlr";
   private static final String SEARCH_ITEMS_URL = "/search/consortium/items";
   private static final String NOT_FOUND_ITEM_UUID = "f13ef24f-d0fe-4aa8-901a-bfad3f0e6cae";
-  private static final String SEARCH_INSTANCES_URL = "/search/instances";
   private static final String SEARCH_ITEM_URL = "/search/consortium/item";
   private static final String HOLDINGS_URL = "/holdings-storage/holdings";
   private static final String MATERIAL_TYPES_URL = "/material-types";
@@ -384,7 +383,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
         .withRequesterId(UUID.fromString(requesterId)));
 
     confirmMediatedRequest(initialRequest.getId())
-      .andExpect(status().isUnprocessableEntity())
+      .andExpect(status().isUnprocessableContent())
       .andExpect(jsonPath("errors").value(iterableWithSize(1)))
       .andExpect(errorCodeMatch(is(MEDIATED_REQUEST_CONFIRM_NOT_ALLOWED_FOR_INACTIVE_PATRON.getCode())))
       .andExpect(errorMessageMatch(is(MEDIATED_REQUEST_CONFIRM_NOT_ALLOWED_FOR_INACTIVE_PATRON.getMessage())))
@@ -511,8 +510,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
   @Test
   @SneakyThrows
   void itemArrivalConfirmationFailsWhenMediatedRequestIsNotFoundByStatus() {
-    MediatedRequestEntity mediatedRequest = mediatedRequestsRepository.save(
-      buildMediatedRequestEntity(OPEN_ITEM_ARRIVED));// wrong status
+    mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_ITEM_ARRIVED));// wrong status
 
     confirmItemArrival("A14837334314")
       .andExpect(status().isNotFound())
@@ -661,7 +659,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
   @SneakyThrows
   @Test
   void sendItemInTransitDoesNotFailWhenItemIsNotFound() {
-    var request = mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_ITEM_ARRIVED)
+    mediatedRequestsRepository.save(buildMediatedRequestEntity(OPEN_ITEM_ARRIVED)
       .withItemId(UUID.fromString(NOT_FOUND_ITEM_UUID)));
     mockHelper.mockItemSearchNotFound(TENANT_ID_CONSORTIUM, NOT_FOUND_ITEM_UUID);
     sendItemInTransit("A14837334314").andExpect(status().isOk());
@@ -680,7 +678,7 @@ class MediatedRequestActionsApiTest extends BaseIT {
   @Test
   @SneakyThrows
   void sendItemInTransitFailsWhenMediatedRequestIsNotFoundByStatus() {
-    MediatedRequestEntity request = mediatedRequestsRepository.save(
+    mediatedRequestsRepository.save(
       buildMediatedRequestEntity(OPEN_IN_TRANSIT_TO_BE_CHECKED_OUT));// wrong status
 
     sendItemInTransit("A14837334314")

--- a/src/test/java/org/folio/mr/util/MockHelper.java
+++ b/src/test/java/org/folio/mr/util/MockHelper.java
@@ -12,6 +12,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
 import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate;
@@ -80,9 +81,18 @@ public class MockHelper {
   }
 
   public void mockItemSearch(String tenantId, String itemId, ConsortiumItem mockItem) {
+    mockItemSearch(tenantId, itemId, asJsonString(mockItem));
+  }
+
+  public void mockItemSearchNotFound(String tenantId, String itemId) {
+    // when item is not found, Item Search API returns 200 with empty JSON body
+    mockItemSearch(tenantId, itemId, "{}");
+  }
+
+  private void mockItemSearch(String tenantId, String itemId, String responseBody) {
     wireMockServer.stubFor(get(urlPathEqualTo(ITEM_SEARCH_URL + "/" + itemId))
       .withHeader(TENANT, equalTo(tenantId))
-      .willReturn(okJson(asJsonString(mockItem))));
+      .willReturn(okJson(responseBody)));
   }
 
   public void mockItemBatchSearch(String tenantId, BatchIds batchIds, ConsortiumItems consortiumItems) {
@@ -92,10 +102,23 @@ public class MockHelper {
       .willReturn(okJson(asJsonString(consortiumItems))));
   }
 
-  public void mockGetRequest(Request request, String tenantId) {
+  public void mockGetRequestFromStorage(Request request, String tenantId) {
     wireMockServer.stubFor(get(urlPathEqualTo(CIRCULATION_STORAGE_REQUESTS_URL + "/" + request.getId()))
       .withHeader(TENANT, equalTo(tenantId))
       .willReturn(okJson(asJsonString(request))));
+  }
+
+  public void mockGetRequest(Request request, String tenantId) {
+    wireMockServer.stubFor(get(urlPathEqualTo(CIRCULATION_REQUESTS_URL + "/" + request.getId()))
+      .withHeader(TENANT, equalTo(tenantId))
+      .willReturn(okJson(asJsonString(request))));
+  }
+
+  public void mockPutRequest(Request request, String tenantId) {
+    wireMockServer.stubFor(put(urlPathEqualTo(CIRCULATION_REQUESTS_URL + "/" + request.getId()))
+      .withHeader(TENANT, equalTo(tenantId))
+      .withRequestBody(equalToJson(asJsonString(request)))
+      .willReturn(noContent()));
   }
 
   public void mockGetLoan(Loan loan, String tenantId) {

--- a/src/test/java/org/folio/mr/util/MockHelper.java
+++ b/src/test/java/org/folio/mr/util/MockHelper.java
@@ -114,10 +114,9 @@ public class MockHelper {
       .willReturn(okJson(asJsonString(request))));
   }
 
-  public void mockPutRequest(Request request, String tenantId) {
-    wireMockServer.stubFor(put(urlPathEqualTo(CIRCULATION_REQUESTS_URL + "/" + request.getId()))
+  public void mockPutRequest(String requestId, String tenantId) {
+    wireMockServer.stubFor(put(urlPathEqualTo(CIRCULATION_REQUESTS_URL + "/" + requestId))
       .withHeader(TENANT, equalTo(tenantId))
-      .withRequestBody(equalToJson(asJsonString(request)))
       .willReturn(noContent()));
   }
 


### PR DESCRIPTION
## Purpose
Do not throw an exception when an item is not found during item arrival confirmation and sending item in transit. This brings back the behavior we had before migration to folio-spring-support 10.
[MODREQMED-224](https://folio-org.atlassian.net/browse/MODREQMED-224)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
