### PR TITLE
MODREQMED-185: Do not forward loan actions to central tenant for local requests

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -162,7 +162,8 @@
             "circulation-storage.requests.item.get",
             "circulation-storage.requests.collection.get",
             "tlr.loans.declare-item-lost.execute",
-            "inventory-storage.items.item.get"
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get"
           ]
         },
         {
@@ -178,7 +179,8 @@
             "circulation-storage.requests.item.get",
             "circulation-storage.requests.collection.get",
             "tlr.loans.claim-item-returned.execute",
-            "inventory-storage.items.item.get"
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get"
           ]
         },
         {
@@ -193,7 +195,8 @@
             "circulation-storage.loans.item.get",
             "circulation-storage.requests.item.get",
             "circulation-storage.requests.collection.get",
-            "inventory-storage.items.item.get"
+            "inventory-storage.items.item.get",
+            "inventory-storage.items.collection.get"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -161,7 +161,8 @@
             "circulation-storage.loans.collection.get",
             "circulation-storage.requests.item.get",
             "circulation-storage.requests.collection.get",
-            "tlr.loans.declare-item-lost.execute"
+            "tlr.loans.declare-item-lost.execute",
+            "inventory-storage.items.item.get"
           ]
         },
         {
@@ -176,7 +177,8 @@
             "circulation-storage.loans.collection.get",
             "circulation-storage.requests.item.get",
             "circulation-storage.requests.collection.get",
-            "tlr.loans.claim-item-returned.execute"
+            "tlr.loans.claim-item-returned.execute",
+            "inventory-storage.items.item.get"
           ]
         },
         {
@@ -190,7 +192,8 @@
             "circulation-storage.loans.collection.get",
             "circulation-storage.loans.item.get",
             "circulation-storage.requests.item.get",
-            "circulation-storage.requests.collection.get"
+            "circulation-storage.requests.collection.get",
+            "inventory-storage.items.item.get"
           ]
         }
       ]

--- a/src/main/java/org/folio/mr/service/impl/MediatedRequestsLoansActionServiceImpl.java
+++ b/src/main/java/org/folio/mr/service/impl/MediatedRequestsLoansActionServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.mr.service.impl;
 
 import static java.util.Optional.ofNullable;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -19,6 +20,7 @@ import org.folio.mr.domain.entity.MediatedRequestEntity;
 import org.folio.mr.repository.MediatedRequestsRepository;
 import org.folio.mr.service.CirculationStorageService;
 import org.folio.mr.service.ConsortiumService;
+import org.folio.mr.service.InventoryService;
 import org.folio.mr.service.MediatedRequestsLoansActionService;
 import org.folio.spring.exception.NotFoundException;
 import org.folio.spring.service.SystemUserScopedExecutionService;
@@ -40,6 +42,7 @@ public class MediatedRequestsLoansActionServiceImpl implements MediatedRequestsL
   private final SystemUserScopedExecutionService systemUserService;
   private final ConsortiumService consortiumService;
   private final CirculationStorageService circulationStorageService;
+  private final InventoryService inventoryService;
 
   @Override
   public void declareLost(UUID loanId, DeclareLostCirculationRequest declareLostRequest) {
@@ -91,12 +94,24 @@ public class MediatedRequestsLoansActionServiceImpl implements MediatedRequestsL
   }
 
   private void executeInCentralTenant(MediatedRequestEntity mediatedRequest, Consumer<String> action) {
+    if (localItemExists(mediatedRequest)) {
+      log.info("executeInCentralTenant:: item found in local inventory, doing nothing");
+      return;
+    }
+
     systemUserService.executeAsyncSystemUserScoped(consortiumService.getCentralTenantId(),
       () -> ofNullable(mediatedRequest.getConfirmedRequestId())
         .map(UUID::toString)
         .map(this::fetchRequestLocally)
         .map(Request::getRequesterId)
         .ifPresent(action));
+  }
+
+  private boolean localItemExists(MediatedRequestEntity mediatedRequest) {
+    return Optional.ofNullable(mediatedRequest.getItemId())
+      .map(UUID::toString)
+      .map(inventoryService::fetchItem)
+      .isPresent();
   }
 
   private void claimItemReturnedInTlr(UUID itemId, String fakeRequesterId,

--- a/src/main/java/org/folio/mr/service/impl/MediatedRequestsLoansActionServiceImpl.java
+++ b/src/main/java/org/folio/mr/service/impl/MediatedRequestsLoansActionServiceImpl.java
@@ -95,7 +95,7 @@ public class MediatedRequestsLoansActionServiceImpl implements MediatedRequestsL
 
   private void executeInCentralTenant(MediatedRequestEntity mediatedRequest, Consumer<String> action) {
     if (localItemExists(mediatedRequest)) {
-      log.info("executeInCentralTenant:: item found in local inventory, doing nothing");
+      log.info("executeInCentralTenant:: item found in local inventory, skipping action in central tenant");
       return;
     }
 

--- a/src/test/java/org/folio/mr/service/MediatedRequestLoansActionServiceTest.java
+++ b/src/test/java/org/folio/mr/service/MediatedRequestLoansActionServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 
 import org.folio.mr.client.CirculationErrorForwardingClient;
 import org.folio.mr.client.LoanClient;
@@ -145,9 +146,7 @@ class MediatedRequestLoansActionServiceTest {
       .servicePointId(SERVICE_POINT_ID)
       .comment(COMMENT);
 
-    initMocksForLocalRequest();
-    service.declareLost(LOAN_ID, request);
-    verifyNoInteractions(systemUserService, tlrClient, circulationStorageService);
+    actionShouldNotBeForwardedToTlrIfLocalItemExists(request, service::declareLost);
   }
 
   @Test
@@ -156,9 +155,7 @@ class MediatedRequestLoansActionServiceTest {
       .itemClaimedReturnedDateTime(ACTION_DATE)
       .comment(COMMENT);
 
-    initMocksForLocalRequest();
-    service.claimItemReturned(LOAN_ID, request);
-    verifyNoInteractions(systemUserService, tlrClient, circulationStorageService);
+    actionShouldNotBeForwardedToTlrIfLocalItemExists(request, service::claimItemReturned);
   }
 
   @Test
@@ -166,8 +163,14 @@ class MediatedRequestLoansActionServiceTest {
     var request = new DeclareClaimedReturnedItemAsMissingCirculationRequest()
       .comment(COMMENT);
 
+    actionShouldNotBeForwardedToTlrIfLocalItemExists(request, service::declareItemMissing);
+  }
+
+  private <T> void actionShouldNotBeForwardedToTlrIfLocalItemExists(T request,
+    BiConsumer<UUID, T> action) {
+
     initMocksForLocalRequest();
-    service.declareItemMissing(LOAN_ID, request);
+    action.accept(LOAN_ID, request);
     verifyNoInteractions(systemUserService, tlrClient, circulationStorageService);
   }
 

--- a/src/test/java/org/folio/mr/service/MediatedRequestLoansActionServiceTest.java
+++ b/src/test/java/org/folio/mr/service/MediatedRequestLoansActionServiceTest.java
@@ -163,9 +163,8 @@ class MediatedRequestLoansActionServiceTest {
 
   @Test
   void declareLocalItemMissingShouldNotForwardToTlr() {
-    DeclareClaimedReturnedItemAsMissingCirculationRequest request =
-      new DeclareClaimedReturnedItemAsMissingCirculationRequest()
-        .comment(COMMENT);
+    var request = new DeclareClaimedReturnedItemAsMissingCirculationRequest()
+      .comment(COMMENT);
 
     initMocksForLocalRequest();
     service.declareItemMissing(LOAN_ID, request);

--- a/src/test/java/org/folio/mr/service/MediatedRequestLoansActionServiceTest.java
+++ b/src/test/java/org/folio/mr/service/MediatedRequestLoansActionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Date;
@@ -21,6 +22,7 @@ import org.folio.mr.domain.dto.DeclareClaimedReturnedItemAsMissingCirculationReq
 import org.folio.mr.domain.dto.DeclareClaimedReturnedItemAsMissingTlrRequest;
 import org.folio.mr.domain.dto.DeclareLostCirculationRequest;
 import org.folio.mr.domain.dto.DeclareLostTlrRequest;
+import org.folio.mr.domain.dto.Item;
 import org.folio.mr.domain.dto.Loan;
 import org.folio.mr.domain.dto.Request;
 import org.folio.mr.domain.entity.MediatedRequestEntity;
@@ -63,6 +65,8 @@ class MediatedRequestLoansActionServiceTest {
   private SystemUserScopedExecutionService systemUserService;
   @Mock
   private ConsortiumService consortiumService;
+  @Mock
+  private InventoryService inventoryService;
   @InjectMocks
   private MediatedRequestsLoansActionServiceImpl service;
 
@@ -132,6 +136,40 @@ class MediatedRequestLoansActionServiceTest {
     assertEquals(ITEM_ID, tlrRequest.getItemId());
     assertEquals(FAKE_REQUESTER_ID, tlrRequest.getUserId());
     assertEquals(COMMENT, tlrRequest.getComment());
+  }
+
+  @Test
+  void declareLocalItemLostShouldNotForwardToTlr() {
+    var request = new DeclareLostCirculationRequest()
+      .declaredLostDateTime(ACTION_DATE)
+      .servicePointId(SERVICE_POINT_ID)
+      .comment(COMMENT);
+
+    initMocksForLocalRequest();
+    service.declareLost(LOAN_ID, request);
+    verifyNoInteractions(systemUserService, tlrClient, circulationStorageService);
+  }
+
+  @Test
+  void claimLocalItemReturnedShouldNotForwardToTlr() {
+    var request = new ClaimItemReturnedCirculationRequest()
+      .itemClaimedReturnedDateTime(ACTION_DATE)
+      .comment(COMMENT);
+
+    initMocksForLocalRequest();
+    service.claimItemReturned(LOAN_ID, request);
+    verifyNoInteractions(systemUserService, tlrClient, circulationStorageService);
+  }
+
+  @Test
+  void declareLocalItemMissingShouldNotForwardToTlr() {
+    DeclareClaimedReturnedItemAsMissingCirculationRequest request =
+      new DeclareClaimedReturnedItemAsMissingCirculationRequest()
+        .comment(COMMENT);
+
+    initMocksForLocalRequest();
+    service.declareItemMissing(LOAN_ID, request);
+    verifyNoInteractions(systemUserService, tlrClient, circulationStorageService);
   }
 
   @Test
@@ -211,5 +249,21 @@ class MediatedRequestLoansActionServiceTest {
       .thenReturn(Optional.of(requestInCentralTenant));
     when(consortiumService.getCentralTenantId())
       .thenReturn("central");
+    when(inventoryService.fetchItem(ITEM_ID.toString()))
+      .thenReturn(null);
+  }
+
+  private void initMocksForLocalRequest() {
+    MediatedRequestEntity mediatedRequest = new MediatedRequestEntity();
+    mediatedRequest.setId(MEDIATED_REQUEST_ID);
+    mediatedRequest.setConfirmedRequestId(CONFIRMED_REQUEST_ID);
+    mediatedRequest.setItemId(ITEM_ID);
+
+    when(mediatedRequestsRepository.findLastClosedFilled(REAL_REQUESTER_ID, ITEM_ID))
+      .thenReturn(Optional.of(mediatedRequest));
+    when(loanClient.getLoanById(LOAN_ID.toString()))
+      .thenReturn(Optional.of(buildLoan()));
+    when(inventoryService.fetchItem(ITEM_ID.toString()))
+      .thenReturn(new Item().id(ITEM_ID.toString()));
   }
 }


### PR DESCRIPTION
## Purpose
Do not attempt to forward loan actions to central tenant for local (oLoan) requests, thus avoiding 404s when searching the request in central tenant.
Resolves [MODREQMED-185](https://folio-org.atlassian.net/browse/MODREQMED-185)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
